### PR TITLE
feat: add support for Fairland-platform pool pumps (Inverflow Plus / OEM rebrands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
-# Fairland Pool Heat Pump Integration for Home Assistant
+# Fairland (iGarden) Integration for Home Assistant
 
 [![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub Release](https://img.shields.io/github/release/siedi/ha-fairland.svg)](https://github.com/siedi/ha-fairland/releases)
 
-This integration enables monitoring and control of Fairland pool heat pumps in Home Assistant, connecting directly to Fairland's cloud API rather than using Tuya.
+This integration enables monitoring and control of Fairland pool heat pumps and pool pumps (Inverflow Plus and OEM-rebadged variants such as Madimack) in Home Assistant, connecting directly to Fairland's iGarden cloud API rather than using Tuya.
 
 ## Compatibility
 
-> **Important:** This integration only works with Fairland heat pumps that use the **iGarden app** (and its corresponding firmware/cloud). It is **not compatible** with the Fairland SmartPool app, which is Tuya-based and uses a completely different API.
+> **Important:** This integration only works with Fairland devices that use the **iGarden app** (and its corresponding firmware/cloud). It is **not compatible** with the Fairland SmartPool app, which is Tuya-based and uses a completely different API.
 >
-> If your heat pump is paired with the SmartPool app, look into Tuya-based integrations instead (e.g. [LocalTuya](https://github.com/rospogriern/localtuya) or the built-in Tuya integration).
+> If your device is paired with the SmartPool app, look into Tuya-based integrations instead (e.g. [LocalTuya](https://github.com/rospogriern/localtuya) or the built-in Tuya integration).
+
+## Supported Devices
+
+* Fairland pool heat pumps on the iGarden platform
+* Fairland Inverflow Plus pool pumps on the iGarden platform
+* OEM-rebadged variants of the above — Madimack pool pumps (e.g. Inverflow Plus 1.5hp) are Fairland OEM rebrands and run on the same iGarden cloud, so they are supported as well
 
 ## Features
 
-* Monitor operational parameters of your heat pump
+* Monitor operational parameters of your Fairland device
 * Control settings directly from Home Assistant
-* Support for multiple Fairland heat pump models
+* Support for multiple Fairland heat pump and pool pump models
 * Direct cloud API connection to Fairland (not using Tuya)
 
 ## Installation
@@ -51,28 +57,44 @@ You will need your Fairland app account credentials to set up the integration.
 
 ## Supported Entities
 
-The integration creates various entities to monitor and control your Fairland heat pump:
+The integration creates a range of entities depending on the type of device discovered on your iGarden account.
 
-### Climate Entity
+### For heat pumps
+
+#### Climate Entity
 * Heat pump control (on/off, mode, temperature)
 
-### Sensors
+#### Sensors
 * Current temperature
 * Target temperature
 * Operating mode
 * Energy consumption
 * Other operational parameters
 
-### Switches/Controls
+#### Switches/Controls
 * Power switch
 * Mode selection (Heating, Cooling, Auto)
 * Additional operational controls, which shouldn't be touched unless you know what you're doing
 
-## Energy Monitoring Setup for Fairland Integration
+### For pool pumps
+
+* **Power switch** — turn the pump on/off
+* **Speed Setpoint** (number, 30-100%, slider) — target pump speed in Manual Inverter mode
+* **Backwash Duration** (number, 0-1440 minutes, configuration) — how long a backwash cycle should run
+* **Mode** (select: Manual Inverter / Backwash) — selecting **Backwash** starts a real backwash cycle on the pump
+* **Current Power** (sensor, W) — instantaneous power draw
+* **Backwash Countdown** (sensor, minutes, diagnostic) — minutes remaining in the active backwash cycle
+* **Energy Consumption** (sensor, kWh, `TOTAL_INCREASING`) — cumulative energy, works directly with the Energy Dashboard
+
+## Energy Monitoring
+
+> **Note:** Pool pumps expose `sensor.<device>_energy_consumption` natively (kWh, `TOTAL_INCREASING`) and can be added straight to the Energy Dashboard without the utility_meter / integration recipe below. The recipe in this section is only required for **heat pumps**, which expose instantaneous power (kW) but not cumulative energy.
+
+### Heat pumps: deriving energy from power
 
 To monitor your Fairland heat pump's energy consumption in the Home Assistant Energy Dashboard, you need to create an integration sensor that converts power (kW) to energy (kWh). Follow these steps:
 
-### Option: Configure via YAML
+#### Option: Configure via YAML
 
 1. Add the following configuration to your `configuration.yaml`:
 
@@ -97,22 +119,22 @@ sensor:
 
 3. Restart Home Assistant to apply the changes.
 
-### Adding to Energy Dashboard
+#### Adding to Energy Dashboard
 
 1. Go to **Settings > Dashboards > Energy**.
 2. In the **Electricity grid** section, click **Add Consumption**.
-3. Under **Individual devices**, select your `sensor.fairland_energy_kwh` sensor.
+3. Under **Individual devices**, select your `sensor.fairland_energy_kwh` sensor (heat pumps) or `sensor.<device>_energy_consumption` (pool pumps).
 4. Click **Save**.
 
-Now your Fairland heat pump's energy consumption will be tracked in the Energy Dashboard!
+Now your Fairland device's energy consumption will be tracked in the Energy Dashboard!
 
-### Understanding the Configuration
+#### Understanding the Configuration
 
 * The `integration` sensor automatically converts power (kW) to energy (kWh) by integrating the power usage over time.
 * `unit_prefix`: k ensures the values are displayed in kilowatt-hours (kWh) instead of watt-hours (Wh).
 * The `utility_meter` entities provide daily and monthly consumption statistics.
 
-### Troubleshooting
+#### Troubleshooting
 
 If you don't see data in the Energy Dashboard:
 

--- a/custom_components/fairland/__init__.py
+++ b/custom_components/fairland/__init__.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
     Platform.NUMBER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/custom_components/fairland/const.py
+++ b/custom_components/fairland/const.py
@@ -7,3 +7,9 @@ LOGGER: Logger = getLogger(__package__)
 DOMAIN = "fairland"
 DEFAULT_SCAN_INTERVAL = 30
 ATTRIBUTION = "Data provided by Fairland IOT"
+
+# iGarden cloud device category codes. The cloud returns these on every
+# device in a courtyard; entity platforms dispatch on them so heat pumps and
+# pool pumps (Inverflow Plus and OEM-rebadged variants) don't share dpId maps.
+HEAT_PUMP_CATEGORY_CODE = "heatPump"
+WATER_PUMP_CATEGORY_CODE = "waterPump"

--- a/custom_components/fairland/manifest.json
+++ b/custom_components/fairland/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/siedi/ha-fairland",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/siedi/ha-fairland/issues",
-  "version": "0.2.1"
+  "version": "0.3.0"
 }

--- a/custom_components/fairland/number.py
+++ b/custom_components/fairland/number.py
@@ -6,11 +6,16 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.number import NumberEntity, NumberMode
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import PERCENTAGE, UnitOfTemperature, UnitOfTime
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from .api import FairlandApiClientCommunicationError, FairlandApiClientError
-from .const import DOMAIN, LOGGER
+from .const import (
+    DOMAIN,
+    HEAT_PUMP_CATEGORY_CODE,
+    LOGGER,
+    WATER_PUMP_CATEGORY_CODE,
+)
 from .entity import FairlandEntity
 
 if TYPE_CHECKING:
@@ -20,8 +25,8 @@ if TYPE_CHECKING:
     from .coordinator import FairlandDataUpdateCoordinator
     from .data import FairlandConfigEntry
 
-# Define writable parameters
-NUMBER_TYPES = {
+# Heat-pump writable parameters.
+HEAT_PUMP_NUMBER_TYPES = {
     "116": {
         "name": "Set Water Pump Mode",
         "unit": None,
@@ -85,6 +90,33 @@ NUMBER_TYPES = {
 }
 
 
+# Water-pump writable parameters. The Inverflow Plus pump (and OEM rebadges
+# like Madimack) drives a real motor, so default ranges are deliberately
+# conservative. The dpProperty min/max/step override below means we always
+# clamp to whatever the firmware reports.
+WATER_PUMP_NUMBER_TYPES = {
+    "111": {
+        "name": "Speed Setpoint",
+        "unit": PERCENTAGE,
+        "icon": "mdi:speedometer",
+        "min": 30,
+        "max": 100,
+        "step": 1,
+        "mode": NumberMode.SLIDER,
+    },
+    "104": {
+        "name": "Backwash Duration",
+        "unit": UnitOfTime.MINUTES,
+        "icon": "mdi:timer-sand",
+        "min": 0,
+        "max": 1440,
+        "step": 1,
+        "mode": NumberMode.BOX,
+        "entity_category": EntityCategory.CONFIG,
+    },
+}
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: FairlandConfigEntry,
@@ -96,49 +128,56 @@ async def async_setup_entry(
     entities = []
     devices = entry.runtime_data.coordinator.data
 
-    # Create number entities for each writable parameter
     for device_info in devices:
-        if device_info.get("categoryCode") == "heatPump":
-            if "dps" in device_info:
-                dp_map = {item["dpId"]: item for item in device_info["dps"]}
+        category = device_info.get("categoryCode")
+        if category == HEAT_PUMP_CATEGORY_CODE:
+            number_types = HEAT_PUMP_NUMBER_TYPES
+        elif category == WATER_PUMP_CATEGORY_CODE:
+            number_types = WATER_PUMP_NUMBER_TYPES
+        else:
+            continue
 
-                # Für jeden schreibbaren Parameter prüfen
-                for dp_id, config in NUMBER_TYPES.items():
-                    if dp_id in dp_map:
-                        # Prüfen ob der Parameter schreibbar ist
-                        if dp_map[dp_id].get("dpMode") == "rw":
-                            # Werte spezifische Einstellungen aus dpProperty aus
-                            if "dpProperty" in dp_map[dp_id]:
-                                try:
-                                    prop = json.loads(dp_map[dp_id]["dpProperty"])
-                                    # Aktualisiere min/max/step basierend auf den tatsächlichen Geräteeigenschaften
-                                    if "min" in prop:
-                                        config = config.copy()
-                                        config["min"] = float(prop["min"])
-                                    if "max" in prop:
-                                        config = config.copy()
-                                        config["max"] = float(prop["max"])
-                                    if "step" in prop:
-                                        config = config.copy()
-                                        config["step"] = float(prop["step"])
-                                except (
-                                    json.JSONDecodeError,
-                                    KeyError,
-                                    ValueError,
-                                ) as ex:
-                                    LOGGER.warning(
-                                        "Failed to parse dpProperty for number entity: %s",
-                                        ex,
-                                    )
+        if "dps" not in device_info:
+            continue
 
-                            entities.append(
-                                FairlandNumber(
-                                    coordinator=entry.runtime_data.coordinator,
-                                    device_info=device_info,
-                                    dp_id=dp_id,
-                                    config=config,
-                                )
-                            )
+        dp_map = {item["dpId"]: item for item in device_info["dps"]}
+
+        # Für jeden schreibbaren Parameter prüfen
+        for dp_id, config in number_types.items():
+            if dp_id not in dp_map:
+                continue
+            # Prüfen ob der Parameter schreibbar ist
+            if dp_map[dp_id].get("dpMode") != "rw":
+                continue
+
+            # Werte spezifische Einstellungen aus dpProperty aus
+            if "dpProperty" in dp_map[dp_id]:
+                try:
+                    prop = json.loads(dp_map[dp_id]["dpProperty"])
+                    # Aktualisiere min/max/step basierend auf den tatsächlichen Geräteeigenschaften
+                    if "min" in prop:
+                        config = config.copy()
+                        config["min"] = float(prop["min"])
+                    if "max" in prop:
+                        config = config.copy()
+                        config["max"] = float(prop["max"])
+                    if "step" in prop:
+                        config = config.copy()
+                        config["step"] = float(prop["step"])
+                except (json.JSONDecodeError, KeyError, ValueError) as ex:
+                    LOGGER.warning(
+                        "Failed to parse dpProperty for number entity: %s",
+                        ex,
+                    )
+
+            entities.append(
+                FairlandNumber(
+                    coordinator=entry.runtime_data.coordinator,
+                    device_info=device_info,
+                    dp_id=dp_id,
+                    config=config,
+                )
+            )
 
     async_add_entities(entities, True)
 

--- a/custom_components/fairland/select.py
+++ b/custom_components/fairland/select.py
@@ -1,0 +1,160 @@
+"""Select platform for Fairland integration.
+
+Currently exposes the operating-mode enum on Fairland-platform water pumps
+(dpId 103) as a writable select entity. The cloud accepts native ``int``
+values: ``0`` = Manual Inverter, ``1`` = Backwash.
+
+NOTE: selecting ``Backwash`` will start a real backwash cycle on the pump
+for the duration configured by the ``Backwash Duration`` number entity
+(dpId 104). Treat this as a deliberate user action.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.helpers.entity import DeviceInfo
+
+from .api import FairlandApiClientCommunicationError, FairlandApiClientError
+from .const import DOMAIN, LOGGER, WATER_PUMP_CATEGORY_CODE
+from .entity import FairlandEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import FairlandDataUpdateCoordinator
+    from .data import FairlandConfigEntry
+
+
+WATER_PUMP_MODE_DP_ID = "103"
+WATER_PUMP_MODE_TRANSLATION_KEY = "water_pump_mode"
+
+# Server-side enum int → translation-key option name. Option names are
+# lowercase snake_case to match the translation file convention.
+WATER_PUMP_MODE_INT_TO_OPTION: dict[int, str] = {
+    0: "manual_inverter",
+    1: "backwash",
+}
+WATER_PUMP_MODE_OPTION_TO_INT: dict[str, int] = {
+    v: k for k, v in WATER_PUMP_MODE_INT_TO_OPTION.items()
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: FairlandConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Fairland select platform."""
+    LOGGER.debug("Setting up Fairland select platform")
+
+    entities = []
+    for device_info in entry.runtime_data.coordinator.data:
+        if device_info.get("categoryCode") != WATER_PUMP_CATEGORY_CODE:
+            continue
+        if "dps" not in device_info:
+            continue
+        if not any(
+            dp.get("dpId") == WATER_PUMP_MODE_DP_ID for dp in device_info["dps"]
+        ):
+            continue
+        entities.append(
+            FairlandWaterPumpModeSelect(
+                coordinator=entry.runtime_data.coordinator,
+                device_info=device_info,
+            )
+        )
+    async_add_entities(entities, True)
+
+
+class FairlandWaterPumpModeSelect(FairlandEntity, SelectEntity):
+    """Operating mode select for Fairland-platform water pumps (dpId 103)."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:tune"
+    _attr_translation_key = WATER_PUMP_MODE_TRANSLATION_KEY
+
+    def __init__(
+        self,
+        coordinator: FairlandDataUpdateCoordinator,
+        device_info: dict[str, Any],
+    ) -> None:
+        """Initialize the select entity."""
+        super().__init__(coordinator)
+
+        self._device_info = device_info
+        self._device_id = device_info["id"]
+
+        self._attr_unique_id = f"{DOMAIN}_{self._device_id}_mode"
+        self._attr_options = list(WATER_PUMP_MODE_INT_TO_OPTION.values())
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_info["deviceName"],
+            manufacturer="Fairland",
+            model=device_info.get("deviceName", "Unknown"),
+            sw_version=device_info.get("version", "Unknown"),
+        )
+
+        self._update_state()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    def _update_state(self) -> None:
+        """Update current option from device data."""
+        if "dps" not in self._device_info:
+            return
+        for dp in self._device_info["dps"]:
+            if dp["dpId"] == WATER_PUMP_MODE_DP_ID:
+                raw = dp.get("dpValue")
+                try:
+                    self._attr_current_option = WATER_PUMP_MODE_INT_TO_OPTION.get(
+                        int(raw)
+                    )
+                except (TypeError, ValueError):
+                    self._attr_current_option = None
+                self._attr_available = self._attr_current_option is not None
+                return
+        self._attr_available = False
+
+    async def async_select_option(self, option: str) -> None:
+        """Write a new mode to the pump."""
+        if option not in WATER_PUMP_MODE_OPTION_TO_INT:
+            LOGGER.error("Refusing to set unknown mode option: %r", option)
+            return
+        target_int = WATER_PUMP_MODE_OPTION_TO_INT[option]
+        try:
+            await self.coordinator.config_entry.runtime_data.client.set_device_status(
+                self._device_id,
+                WATER_PUMP_MODE_DP_ID,
+                target_int,
+            )
+            self._attr_current_option = option
+            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()
+        except (FairlandApiClientCommunicationError, FairlandApiClientError) as ex:
+            LOGGER.error("Error setting mode: %s", ex)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_coordinator_update)
+        )
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        for device in self.coordinator.data:
+            if device["id"] == self._device_id:
+                self._device_info = device
+                self._update_state()
+                self.async_write_ha_state()
+                break
+
+    async def async_update(self) -> None:
+        """Update the entity."""
+        await self.coordinator.async_request_refresh()

--- a/custom_components/fairland/sensor.py
+++ b/custom_components/fairland/sensor.py
@@ -10,10 +10,21 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfPower, UnitOfTemperature
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
-from .const import DOMAIN, LOGGER
+from .const import (
+    DOMAIN,
+    HEAT_PUMP_CATEGORY_CODE,
+    LOGGER,
+    WATER_PUMP_CATEGORY_CODE,
+)
 from .entity import FairlandEntity
 
 if TYPE_CHECKING:
@@ -24,8 +35,11 @@ if TYPE_CHECKING:
     from .data import FairlandConfigEntry
 
 
-# Define sensor types with the new detailed data points
-SENSOR_TYPES = {
+# Heat-pump sensor types. dpId namespace is *not* shared with water pumps:
+# e.g. heat-pump dpId 108 = Lower Temperature Limit, water-pump dpId 108 =
+# Backwash Countdown. Dispatch in async_setup_entry guards against the
+# collision.
+HEAT_PUMP_SENSOR_TYPES = {
     # Temperaturen
     "103": {
         "name": "Inlet Water Temperature",
@@ -261,6 +275,36 @@ SENSOR_TYPES = {
 }
 
 
+# Read-only data points exposed by Fairland-platform water pumps (e.g.
+# Inverflow Plus and OEM-rebadged variants such as Madimack). Energy is
+# reported as an integer with a dpProperty scale (typically scale=2), so it
+# rides the same scaling path as heat-pump temperature/power values.
+WATER_PUMP_SENSOR_TYPES = {
+    "5": {
+        "name": "Current Power",
+        "unit": UnitOfPower.WATT,
+        "icon": "mdi:flash",
+        "device_class": SensorDeviceClass.POWER,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "108": {
+        "name": "Backwash Countdown",
+        "unit": UnitOfTime.MINUTES,
+        "icon": "mdi:timer-sand",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "109": {
+        "name": "Energy Consumption",
+        "unit": UnitOfEnergy.KILO_WATT_HOUR,
+        "icon": "mdi:lightning-bolt",
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+}
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: FairlandConfigEntry,
@@ -272,37 +316,46 @@ async def async_setup_entry(
     entities = []
     devices = entry.runtime_data.coordinator.data
 
-    # Create climate entities for each device
     for device_info in devices:
-        if "dps" in device_info:
-            dp_map = {item["dpId"]: item for item in device_info["dps"]}
+        if "dps" not in device_info:
+            continue
 
-            # Für jeden Sensortyp prüfen, ob er verfügbar ist
-            for dp_id, sensor_config in SENSOR_TYPES.items():
-                if dp_id in dp_map:
-                    # scale aus dpProperty übernehmen, falls vorhanden.
-                    # Firmware liefert Temperaturen teils als Integer × 10 (scale=1).
-                    if "dpProperty" in dp_map[dp_id]:
-                        try:
-                            prop = json.loads(dp_map[dp_id]["dpProperty"])
-                            if "scale" in prop:
-                                sensor_config = sensor_config.copy()
-                                sensor_config["scale"] = int(prop["scale"])
-                        except (json.JSONDecodeError, KeyError, ValueError) as ex:
-                            LOGGER.warning(
-                                "Failed to parse dpProperty for dp %s: %s", dp_id, ex
-                            )
+        category = device_info.get("categoryCode")
+        if category == HEAT_PUMP_CATEGORY_CODE:
+            sensor_types = HEAT_PUMP_SENSOR_TYPES
+        elif category == WATER_PUMP_CATEGORY_CODE:
+            sensor_types = WATER_PUMP_SENSOR_TYPES
+        else:
+            continue
 
-                    entities.append(
-                        FairlandSensor(
-                            coordinator=entry.runtime_data.coordinator,
-                            device_info=device_info,
-                            dp_id=dp_id,
-                            sensor_config=sensor_config,
-                        )
-                        # dp_id,
-                        # sensor_config,
+        dp_map = {item["dpId"]: item for item in device_info["dps"]}
+
+        # Für jeden Sensortyp prüfen, ob er verfügbar ist
+        for dp_id, sensor_config in sensor_types.items():
+            if dp_id not in dp_map:
+                continue
+
+            # scale aus dpProperty übernehmen, falls vorhanden.
+            # Firmware liefert Temperaturen teils als Integer × 10 (scale=1).
+            if "dpProperty" in dp_map[dp_id]:
+                try:
+                    prop = json.loads(dp_map[dp_id]["dpProperty"])
+                    if "scale" in prop:
+                        sensor_config = sensor_config.copy()
+                        sensor_config["scale"] = int(prop["scale"])
+                except (json.JSONDecodeError, KeyError, ValueError) as ex:
+                    LOGGER.warning(
+                        "Failed to parse dpProperty for dp %s: %s", dp_id, ex
                     )
+
+            entities.append(
+                FairlandSensor(
+                    coordinator=entry.runtime_data.coordinator,
+                    device_info=device_info,
+                    dp_id=dp_id,
+                    sensor_config=sensor_config,
+                )
+            )
 
     async_add_entities(entities, True)
 

--- a/custom_components/fairland/sensor.py
+++ b/custom_components/fairland/sensor.py
@@ -272,9 +272,6 @@ async def async_setup_entry(
     entities = []
     devices = entry.runtime_data.coordinator.data
 
-    entities = []
-    devices = entry.runtime_data.coordinator.data
-
     # Create climate entities for each device
     for device_info in devices:
         if "dps" in device_info:

--- a/custom_components/fairland/switch.py
+++ b/custom_components/fairland/switch.py
@@ -8,7 +8,12 @@ from homeassistant.components.switch import SwitchEntity, SwitchEntityDescriptio
 from homeassistant.helpers.entity import DeviceInfo
 
 from .api import FairlandApiClientCommunicationError, FairlandApiClientError
-from .const import DOMAIN, LOGGER
+from .const import (
+    DOMAIN,
+    HEAT_PUMP_CATEGORY_CODE,
+    LOGGER,
+    WATER_PUMP_CATEGORY_CODE,
+)
 from .entity import FairlandEntity
 
 if TYPE_CHECKING:
@@ -26,6 +31,12 @@ ENTITY_DESCRIPTIONS = (
     ),
 )
 
+# Power dpId differs per category: heat pumps use dpId 101, water pumps
+# use dpId 105. They cannot share a fixed constant because dpId 105 is the
+# "Running Percentage" diagnostic sensor on heat pumps.
+HEAT_PUMP_POWER_DP_ID = "101"
+WATER_PUMP_POWER_DP_ID = "105"
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -38,19 +49,38 @@ async def async_setup_entry(
     entities = []
     devices = entry.runtime_data.coordinator.data
 
-    # Create switch entities for each device
     for device_info in devices:
-        # Prüfe, ob es sich um eine Wärmepumpe handelt
-        if device_info.get("categoryCode") == "heatPump":
+        category = device_info.get("categoryCode")
+        if category == HEAT_PUMP_CATEGORY_CODE:
             LOGGER.debug("Found heat pump device: %s", device_info["deviceName"])
             entities.append(
                 FairlandSwitch(
                     coordinator=entry.runtime_data.coordinator,
                     device_info=device_info,
                     entity_description=ENTITY_DESCRIPTIONS,
+                    power_dp_id=HEAT_PUMP_POWER_DP_ID,
+                )
+            )
+        elif category == WATER_PUMP_CATEGORY_CODE:
+            # Skip water pumps that don't expose the power dpId at all
+            # (defensive — every firmware seen so far exposes 105).
+            if not _has_dp(device_info, WATER_PUMP_POWER_DP_ID):
+                continue
+            LOGGER.debug("Found water pump device: %s", device_info["deviceName"])
+            entities.append(
+                FairlandSwitch(
+                    coordinator=entry.runtime_data.coordinator,
+                    device_info=device_info,
+                    entity_description=ENTITY_DESCRIPTIONS,
+                    power_dp_id=WATER_PUMP_POWER_DP_ID,
                 )
             )
     async_add_entities(entities, True)
+
+
+def _has_dp(device_info: dict[str, Any], dp_id: str) -> bool:
+    """Return True if device_info advertises the given dpId."""
+    return any(dp.get("dpId") == dp_id for dp in device_info.get("dps", []))
 
 
 class FairlandSwitch(FairlandEntity, SwitchEntity):
@@ -63,6 +93,7 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
         coordinator: FairlandDataUpdateCoordinator,
         device_info: dict[str, Any],
         entity_description: SwitchEntityDescription,
+        power_dp_id: str = "101",
     ) -> None:
         """Initialize the switch class."""
         super().__init__(coordinator)
@@ -71,6 +102,7 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
 
         self._device_info = device_info
         self._device_id = device_info["id"]
+        self._power_dp_id = power_dp_id
 
         self._attr_unique_id = f"{DOMAIN}_{self._device_id}_switch"
         self._attr_name = "Power"
@@ -93,7 +125,7 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
         """Update state from device data."""
         if "dps" in self._device_info:
             for dp in self._device_info["dps"]:
-                if dp["dpId"] == "101":  # Power switch
+                if dp["dpId"] == self._power_dp_id:
                     self._is_on = dp["dpValue"]
                     self._attr_available = True
                     return
@@ -133,15 +165,9 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
         try:
-            # await self.hass.async_add_executor_job(
-            #    self._api.set_device_status,
-            #    self._device_id,
-            #    "101",  # Power switch data point
-            #    True,
-            # )
             await self.coordinator.config_entry.runtime_data.client.set_device_status(
                 self._device_id,
-                "101",  # Power switch data point
+                self._power_dp_id,
                 True,
             )
             self._is_on = True
@@ -157,7 +183,7 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
         try:
             await self.coordinator.config_entry.runtime_data.client.set_device_status(
                 self._device_id,
-                "101",  # Power switch data point
+                self._power_dp_id,
                 False,
             )
             self._is_on = False

--- a/custom_components/fairland/translations/en.json
+++ b/custom_components/fairland/translations/en.json
@@ -39,5 +39,16 @@
       "no_courtyards": "No courtyards found for this account",
       "reconfigure_successful": "Reconfiguration successful"
     }
+  },
+  "entity": {
+    "select": {
+      "water_pump_mode": {
+        "name": "Mode",
+        "state": {
+          "manual_inverter": "Manual Inverter",
+          "backwash": "Backwash"
+        }
+      }
+    }
   }
 }

--- a/custom_components/fairland/translations/en.json
+++ b/custom_components/fairland/translations/en.json
@@ -8,7 +8,7 @@
           "countryCode": "Country Code",
           "scan_interval": "Scan Interval (seconds)"
         },
-        "description": "Enter your Fairland iGarden app credentials. This integration only works with the **iGarden app**, not the SmartPool app.",
+        "description": "Enter your Fairland iGarden app credentials. This integration supports Fairland pool heat pumps and pool pumps (including OEM-rebadged variants such as Madimack) and only works with the **iGarden app**, not the SmartPool app.",
         "title": "Fairland (iGarden) Account Setup"
       },
       "courtyard": {


### PR DESCRIPTION
Tested against a Madimack Inverflow Plus 1.5HP pool pump into Home Assistant.

  ## Summary

  Adds support for Fairland-platform pool pumps (Inverflow Plus and OEM-rebadged
  variants such as Madimack Inverflow Plus 1.5hp) alongside the existing heat-pump
  support. Both device classes live on the same iGarden cloud — the coordinator
  already fetches every device in a courtyard regardless of category, so this PR
  is purely a matter of teaching each platform how to dispatch on `categoryCode`.

  No existing heat-pump behavior changes. The integration domain, codeowner,
  `manufacturer="Fairland"` in `DeviceInfo`, country-code default (`DE`), and
  config-flow shape are all untouched. Existing installs upgrade in place.

  ## Why dispatch on `categoryCode`?

  dpId namespaces are **not shared** between heat pumps and water pumps:

  | dpId | Heat-pump meaning           | Water-pump meaning       |
  | ---- | --------------------------- | ------------------------ |
  | 105  | Running Percentage (sensor) | Power switch             |
  | 108  | Lower Temperature Limit     | Backwash Countdown       |
  | 109  | Upper Temperature Limit     | Energy Consumption (kWh) |

  Appending water-pump entries to the existing dicts would emit nonsense entities
  on heat pumps and vice-versa. Each platform now branches on
  `categoryCode in {HEAT_PUMP_CATEGORY_CODE, WATER_PUMP_CATEGORY_CODE}` and
  selects the matching dpId map. Devices in unrecognised categories produce no
  entities (previously the sensor platform would have happily applied heat-pump
  labels to them).

  ## New entities (pool pumps only)

  | Entity                              | dpId | Notes |
  | ----------------------------------- | ---- | ----- |
  | `switch.<device>_power`             | 105  | On/off |
  | `number.<device>_speed_setpoint`    | 111  | 30–100 %, slider |
  | `number.<device>_backwash_duration` | 104  | 0–1440 min, box, CONFIG |
  | `select.<device>_mode`              | 103  | `Manual Inverter` / `Backwash` (selecting Backwash starts a real cycle) |
  | `sensor.<device>_current_power`     | 5    | W |
  | `sensor.<device>_backwash_countdown`| 108  | minutes, diagnostic |
  | `sensor.<device>_energy_consumption`| 109  | kWh, `TOTAL_INCREASING` — drops straight onto the Energy Dashboard |

  ## Files

  * `const.py` — `HEAT_PUMP_CATEGORY_CODE` / `WATER_PUMP_CATEGORY_CODE`
  * `sensor.py` — `HEAT_PUMP_SENSOR_TYPES` (was `SENSOR_TYPES`) + new `WATER_PUMP_SENSOR_TYPES`; setup dispatches by category. Drive-by removed a duplicated `entities = []` / `devices = …` block.
  * `switch.py` — parameterised `power_dp_id` (defaults to `"101"`); water-pump branch uses `"105"`.
  * `number.py` — `HEAT_PUMP_NUMBER_TYPES` + new `WATER_PUMP_NUMBER_TYPES`. The existing `dpMode == "rw"` filter and `dpProperty` min/max/step override apply to both branches, so firmware-declared
  ranges always win — important because the pump drives a real 1.5 kW motor.
  * `select.py` — **new platform**. `FairlandWaterPumpModeSelect` for dpId 103. Translation strings live under `entity.select.water_pump_mode` so the options are localisable.
  * `__init__.py` — registers `Platform.SELECT`.
  * `translations/en.json` — adds the new select strings; tweaks the user-step description to mention pool pumps.
  * `README.md` — generalises intro; adds "Supported Devices" and a pool-pump entity subsection; scopes the existing power→energy utility-meter recipe to heat pumps and notes the native kWh sensor on   pool pumps.
  * `manifest.json` — `0.2.1` → `0.3.0`.

## Test Plan
 - [x] `bash scripts/lint` passes
  - [x] Existing heat-pump install still produces the same climate / number / sensor / switch entities (verified by diff — heat-pump code paths are unchanged aside from the `SENSOR_TYPES` →
  `HEAT_PUMP_SENSOR_TYPES` rename and the explicit `categoryCode == "heatPump"` filter)
  - [x] Real-device test against an Inverflow Plus pool pump (Madimack 1.5hp): the seven entities above appear, current values round-trip, speed setpoint slider writes, mode select reflects current
  value
  - [x] Energy Consumption sensor adds to the Energy Dashboard without a utility_meter recipe
  - [x] Backwash mode/duration deliberately not exercised end-to-end on the test rig

  ## Compatibility notes

  Madimack pool pumps are Fairland OEM rebrands running the same iGarden cloud
  and firmware family, so no Madimack-specific branding is needed in code. The
  README mentions them under "Supported Devices" so users searching for
  "Madimack" can find this integration.

  The pre-existing hard-coded `DE`/`49` phone-code in `api.login()` is unrelated
  to pool-pump support and left for a separate PR.