### PR TITLE
feat: salt chlorinator + multiport valve support, plus test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+permissions: {}
+
+jobs:
+  pytest:
+    name: "Pytest"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install requirements
+        run: python3 -m pip install -r requirements-test.txt
+
+      - name: Run tests
+        run: python3 -m pytest tests/ -q

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ coverage.xml
 # Home Assistant configuration
 config/*
 !config/configuration.yaml
+
+
+# Local diagnostics archive: raw user-attached JSONs kept for reference.
+# Never committed (PII + size). Only the README documenting the convention is.
+diagnostics/*
+!diagnostics/README.md

--- a/custom_components/fairland/__init__.py
+++ b/custom_components/fairland/__init__.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 
 PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.NUMBER,
     Platform.SELECT,

--- a/custom_components/fairland/binary_sensor.py
+++ b/custom_components/fairland/binary_sensor.py
@@ -74,6 +74,15 @@ SALT_MACHINE_BINARY_SENSOR_TYPES: dict[str, dict[str, Any]] = {
         "entity_category": EntityCategory.DIAGNOSTIC,
         "require_value": True,
     },
+    # dp 116 true = 校准 ("Calibration required" per firmware nameLanguage) —
+    # a status/alarm like salt-low and replace-probe, not inverted.
+    "116": {
+        "name": "Calibration Required",
+        "icon": "mdi:tune-vertical",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+        "require_value": True,
+    },
     # dp 154 true = 泳池盖盖上 (pool cover closed). Informational, not a fault.
     "154": {
         "name": "Pool Cover Closed",

--- a/custom_components/fairland/binary_sensor.py
+++ b/custom_components/fairland/binary_sensor.py
@@ -1,0 +1,193 @@
+"""Binary sensor platform for Fairland integration.
+
+Provides protection/alarm and status indicators for inverter salt
+chlorinators (saltMachine, issue #80). These data points come back as
+``null`` on firmwares that don't implement them, so creation is gated on
+``require_value`` where appropriate.
+
+Polarity is derived from the firmware's own dpProperty true/false labels
+rather than guessed: e.g. dp 114 reports ``true`` = 有水流 (flow present),
+so as a PROBLEM sensor it is inverted (the problem is *no* flow), while
+dp 117 reports ``true`` = 加盐 (salt needs topping up), which is already
+the problem state and is not inverted.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+
+from .const import (
+    DOMAIN,
+    LOGGER,
+    SALT_MACHINE_CATEGORY_CODE,
+)
+from .entity import FairlandEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import FairlandDataUpdateCoordinator
+    from .data import FairlandConfigEntry
+
+
+# Salt-chlorinator binary sensors. `invert` flips the firmware value so the
+# displayed state matches the device class (e.g. PROBLEM = on when faulted).
+# `require_value` skips creation when the firmware never populates the dp.
+SALT_MACHINE_BINARY_SENSOR_TYPES: dict[str, dict[str, Any]] = {
+    # dp 114 true = 有水流 (flow present); the fault is the absence of flow.
+    "114": {
+        "name": "Water Flow Fault",
+        "icon": "mdi:water-alert",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+        "invert": True,
+        "require_value": True,
+    },
+    # dp 115 true = 加酸 (acid dosing active) — a running indicator, not a fault.
+    "115": {
+        "name": "Acid Dosing",
+        "icon": "mdi:eyedropper",
+        "device_class": BinarySensorDeviceClass.RUNNING,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+        "require_value": True,
+    },
+    # dp 117 true = 加盐 (salt needs topping up) — already the problem state.
+    "117": {
+        "name": "Salt Low",
+        "icon": "mdi:shaker-outline",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+        "require_value": True,
+    },
+    # dp 118 true = 更换探头 (replace probe) — already the problem state.
+    "118": {
+        "name": "Replace Probe",
+        "icon": "mdi:test-tube",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+        "require_value": True,
+    },
+    # dp 154 true = 泳池盖盖上 (pool cover closed). Informational, not a fault.
+    "154": {
+        "name": "Pool Cover Closed",
+        "icon": "mdi:window-shutter",
+        "device_class": None,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+}
+
+CATEGORY_BINARY_SENSOR_TYPES = {
+    SALT_MACHINE_CATEGORY_CODE: SALT_MACHINE_BINARY_SENSOR_TYPES,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: FairlandConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Fairland binary sensor platform."""
+    LOGGER.debug("Setting up Fairland binary sensor platform")
+
+    entities: list[BinarySensorEntity] = []
+    for device_info in entry.runtime_data.coordinator.data:
+        sensor_types = CATEGORY_BINARY_SENSOR_TYPES.get(device_info.get("categoryCode"))
+        if sensor_types is None:
+            continue
+
+        dp_map = {dp.get("dpId"): dp for dp in device_info.get("dps", [])}
+        for dp_id, config in sensor_types.items():
+            if dp_id not in dp_map:
+                continue
+            if config.get("require_value") and dp_map[dp_id].get("dpValue") is None:
+                LOGGER.debug(
+                    "Skipping binary sensor dp %s: firmware does not populate it",
+                    dp_id,
+                )
+                continue
+            entities.append(
+                FairlandBinarySensor(
+                    coordinator=entry.runtime_data.coordinator,
+                    device_info=device_info,
+                    dp_id=dp_id,
+                    config=config,
+                )
+            )
+
+    if entities:
+        LOGGER.debug("Adding %d Fairland binary sensors", len(entities))
+    async_add_entities(entities, True)
+
+
+class FairlandBinarySensor(FairlandEntity, BinarySensorEntity):
+    """Representation of a Fairland binary sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: FairlandDataUpdateCoordinator,
+        device_info: dict[str, Any],
+        dp_id: str,
+        config: dict[str, Any],
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+
+        self._device_info = device_info
+        self._device_id = device_info["id"]
+        self._dp_id = dp_id
+        self._invert = bool(config.get("invert", False))
+
+        self._attr_name = config["name"]
+        self._attr_icon = config.get("icon")
+        self._attr_device_class = config.get("device_class")
+        self._attr_entity_category = config.get("entity_category")
+        self._attr_unique_id = f"{DOMAIN}_{self._device_id}_bs_{dp_id}"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_info["deviceName"],
+            manufacturer="Fairland",
+            model=device_info.get("deviceName", "Unknown"),
+            sw_version=device_info.get("version", "Unknown"),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the sensor is on (None if not yet reported)."""
+        for device in self.coordinator.data:
+            if device.get("id") != self._device_id:
+                continue
+            for dp in device.get("dps", []):
+                if dp.get("dpId") != self._dp_id:
+                    continue
+                raw = dp.get("dpValue")
+                if raw is None:
+                    return None
+                val = _coerce_bool(raw)
+                return (not val) if self._invert else val
+        return None
+
+
+def _coerce_bool(raw: Any) -> bool:
+    """Coerce a dpValue (bool / 0|1 / "0"|"1"|"on") to a boolean state."""
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return raw != 0
+    if isinstance(raw, str):
+        return raw.strip().lower() in ("1", "true", "on", "yes")
+    return bool(raw)

--- a/custom_components/fairland/const.py
+++ b/custom_components/fairland/const.py
@@ -34,3 +34,6 @@ WATER_PUMP_CATEGORY_CODE = "waterPump"
 # Inverter salt chlorinator (Fairland i-Salt and OEM rebrands, issue #80).
 # A wholly separate dpId namespace from heat/water pumps.
 SALT_MACHINE_CATEGORY_CODE = "saltMachine"
+# Multiport valve / sand-filter controller (MPV, issue #80/#81). Again its
+# own dpId namespace.
+SAND_CYLINDER_CATEGORY_CODE = "sandCylinder"

--- a/custom_components/fairland/const.py
+++ b/custom_components/fairland/const.py
@@ -31,3 +31,6 @@ CONF_API_REGION = "api_region"
 # pool pumps (Inverflow Plus and OEM-rebadged variants) don't share dpId maps.
 HEAT_PUMP_CATEGORY_CODE = "heatPump"
 WATER_PUMP_CATEGORY_CODE = "waterPump"
+# Inverter salt chlorinator (Fairland i-Salt and OEM rebrands, issue #80).
+# A wholly separate dpId namespace from heat/water pumps.
+SALT_MACHINE_CATEGORY_CODE = "saltMachine"

--- a/custom_components/fairland/number.py
+++ b/custom_components/fairland/number.py
@@ -24,6 +24,7 @@ from .const import (
     HEAT_PUMP_CATEGORY_CODE,
     LOGGER,
     SALT_MACHINE_CATEGORY_CODE,
+    SAND_CYLINDER_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
 )
 from .entity import FairlandEntity
@@ -184,6 +185,72 @@ SALT_MACHINE_NUMBER_TYPES = {
 }
 
 
+# Multiport valve / sand-filter controller (sandCylinder, #80/#81) writable
+# setpoints. Names from the firmware nameLanguage (en-US). min/max/step come
+# from each device's dpProperty; the trigger pressure (dp 105) arrives in MPa
+# as an integer × 1000, so it opts into dpProperty scaling.
+SAND_CYLINDER_NUMBER_TYPES = {
+    "105": {
+        "name": "Backwash Trigger Pressure",
+        "unit": "MPa",
+        "icon": "mdi:gauge",
+        "min": 0,
+        "max": 2.5,
+        "step": 0.001,
+        "mode": NumberMode.BOX,
+        "scale_from_property": True,
+    },
+    "108": {
+        "name": "Low Temperature Protection",
+        "unit": UnitOfTemperature.CELSIUS,
+        "icon": "mdi:snowflake-thermometer",
+        "min": 0,
+        "max": 5,
+        "step": 1,
+        "mode": NumberMode.BOX,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "109": {
+        "name": "Timed Backwash Interval",
+        "unit": UnitOfTime.DAYS,
+        "icon": "mdi:calendar-refresh",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "mode": NumberMode.BOX,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "111": {
+        "name": "Backwash Duration",
+        "unit": UnitOfTime.MINUTES,
+        "icon": "mdi:timer-sand",
+        "min": 1,
+        "max": 25,
+        "step": 1,
+        "mode": NumberMode.BOX,
+    },
+    "112": {
+        "name": "Washing Time Ratio",
+        "unit": PERCENTAGE,
+        "icon": "mdi:percent",
+        "min": 10,
+        "max": 50,
+        "step": 1,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "113": {
+        "name": "VS Pump Backwash Speed",
+        "unit": PERCENTAGE,
+        "icon": "mdi:speedometer",
+        "min": 60,
+        "max": 100,
+        "step": 5,
+        "mode": NumberMode.SLIDER,
+    },
+}
+
+
 # Firmware-reported time units (dpProperty "unit") we trust to override a
 # default time unit: the backwash duration comes in seconds on some pumps
 # (e.g. InverFlow(L), issue #77) and minutes on others.
@@ -212,6 +279,8 @@ async def async_setup_entry(
             number_types = WATER_PUMP_NUMBER_TYPES
         elif category == SALT_MACHINE_CATEGORY_CODE:
             number_types = SALT_MACHINE_NUMBER_TYPES
+        elif category == SAND_CYLINDER_CATEGORY_CODE:
+            number_types = SAND_CYLINDER_NUMBER_TYPES
         else:
             continue
 

--- a/custom_components/fairland/number.py
+++ b/custom_components/fairland/number.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.number import NumberEntity, NumberMode
-from homeassistant.const import PERCENTAGE, UnitOfTemperature, UnitOfTime
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberMode,
+)
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfElectricPotential,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from .api import FairlandApiClientCommunicationError, FairlandApiClientError
@@ -14,6 +23,7 @@ from .const import (
     DOMAIN,
     HEAT_PUMP_CATEGORY_CODE,
     LOGGER,
+    SALT_MACHINE_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
 )
 from .entity import FairlandEntity
@@ -116,6 +126,64 @@ WATER_PUMP_NUMBER_TYPES = {
     },
 }
 
+# Inverter salt chlorinator (saltMachine) writable setpoints (issue #80).
+# min/max/step are overridden from each device's dpProperty below, so the
+# defaults here are only fallbacks. pH (dp 110) arrives as an integer × 10,
+# so it opts into dpProperty scaling (`scale_from_property`) to read and
+# write in real pH units.
+SALT_MACHINE_NUMBER_TYPES = {
+    "110": {
+        "name": "pH Setpoint",
+        "unit": None,
+        "icon": "mdi:ph",
+        "device_class": NumberDeviceClass.PH,
+        "min": 6.5,
+        "max": 8.5,
+        "step": 0.1,
+        "mode": NumberMode.BOX,
+        "scale_from_property": True,
+    },
+    "108": {
+        "name": "ORP Setpoint",
+        "unit": UnitOfElectricPotential.MILLIVOLT,
+        "icon": "mdi:test-tube",
+        "min": 200,
+        "max": 850,
+        "step": 10,
+        "mode": NumberMode.SLIDER,
+    },
+    "125": {
+        "name": "Target Chlorine Output",
+        "unit": PERCENTAGE,
+        "icon": "mdi:gauge",
+        "min": 0,
+        "max": 130,
+        "step": 5,
+        "mode": NumberMode.SLIDER,
+    },
+    "109": {
+        "name": "Pool Volume",
+        "unit": "m³",
+        "icon": "mdi:pool",
+        "min": 5,
+        "max": 100,
+        "step": 5,
+        "mode": NumberMode.BOX,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "126": {
+        "name": "Acid Dosing Rate",
+        "unit": "ml/day",
+        "icon": "mdi:eyedropper",
+        "min": 0,
+        "max": 9990,
+        "step": 10,
+        "mode": NumberMode.BOX,
+        "entity_category": EntityCategory.CONFIG,
+    },
+}
+
+
 # Firmware-reported time units (dpProperty "unit") we trust to override a
 # default time unit: the backwash duration comes in seconds on some pumps
 # (e.g. InverFlow(L), issue #77) and minutes on others.
@@ -142,6 +210,8 @@ async def async_setup_entry(
             number_types = HEAT_PUMP_NUMBER_TYPES
         elif category == WATER_PUMP_CATEGORY_CODE:
             number_types = WATER_PUMP_NUMBER_TYPES
+        elif category == SALT_MACHINE_CATEGORY_CODE:
+            number_types = SALT_MACHINE_NUMBER_TYPES
         else:
             continue
 
@@ -162,16 +232,25 @@ async def async_setup_entry(
             if "dpProperty" in dp_map[dp_id]:
                 try:
                     prop = json.loads(dp_map[dp_id]["dpProperty"])
+                    # Manche Werte kommen als Integer × 10^scale (z.B. der
+                    # pH-Sollwert mit scale=1). dpProperty min/max/step liegen
+                    # dann ebenfalls im rohen Raum, also alle herunterskalieren.
+                    factor = 1.0
+                    if config.get("scale_from_property") and int(prop.get("scale", 0)):
+                        scale = int(prop["scale"])
+                        factor = 10**scale
+                        config = config.copy()
+                        config["scale"] = scale
                     # Aktualisiere min/max/step basierend auf den tatsächlichen Geräteeigenschaften
                     if "min" in prop:
                         config = config.copy()
-                        config["min"] = float(prop["min"])
+                        config["min"] = float(prop["min"]) / factor
                     if "max" in prop:
                         config = config.copy()
-                        config["max"] = float(prop["max"])
+                        config["max"] = float(prop["max"]) / factor
                     if "step" in prop:
                         config = config.copy()
-                        config["step"] = float(prop["step"])
+                        config["step"] = float(prop["step"]) / factor
                     # Zeit-Einheit aus der Firmware übernehmen: manche Pumpen
                     # melden die Backwash-Dauer in Sekunden statt Minuten (#77).
                     if (
@@ -217,12 +296,16 @@ class FairlandNumber(FairlandEntity, NumberEntity):
         self._device_id = device_info["id"]
         self._dp_id = dp_id
         self._config = config
+        # Firmware reports/accepts the raw integer value × 10^scale (e.g. pH
+        # as 74 for 7.4); 0 means the value is already in display units.
+        self._scale = config.get("scale", 0)
 
         # Set attributes based on config
         self._attr_name = config["name"]
         self._attr_unique_id = f"{DOMAIN}_{self._device_id}_{dp_id}_control"
         self._attr_native_unit_of_measurement = config.get("unit")
         self._attr_icon = config.get("icon")
+        self._attr_device_class = config.get("device_class")
         self._attr_entity_category = config.get("entity_category")
         self._attr_native_min_value = config["min"]
         self._attr_native_max_value = config["max"]
@@ -251,9 +334,10 @@ class FairlandNumber(FairlandEntity, NumberEntity):
         if "dps" in self._device_info:
             for dp in self._device_info["dps"]:
                 if dp["dpId"] == self._dp_id:
-                    self._attr_native_value = self._effective_dp_value(
-                        self._dp_id, dp["dpValue"]
-                    )
+                    value = self._effective_dp_value(self._dp_id, dp["dpValue"])
+                    if self._scale > 0 and value is not None:
+                        value = value / (10**self._scale)
+                    self._attr_native_value = value
                     self._attr_available = True
                     return
 
@@ -262,23 +346,29 @@ class FairlandNumber(FairlandEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         try:
-            # Runde den Wert basierend auf dem Step
-            if self._attr_native_step.is_integer():
-                rounded_value = int(round(value))
+            # Scaled values (e.g. pH 7.4) go to the firmware as the raw
+            # integer (74); unscaled values round to the step granularity.
+            if self._scale > 0:
+                raw_value = int(round(value * (10**self._scale)))
+            elif self._attr_native_step.is_integer():
+                raw_value = int(round(value))
             else:
-                rounded_value = round(value, 2)
+                raw_value = round(value, 2)
 
             await self.coordinator.config_entry.runtime_data.client.set_device_status(
                 self._device_id,
                 self._dp_id,
-                rounded_value,
+                raw_value,
             )
 
             # Optimistisch setzen; die Cloud meldet den neuen Wert erst nach
             # 2-4 s zurück, ein sofortiger Refresh würde den alten Wert lesen
-            # und die UI zurückspringen lassen (#77).
-            self._note_pending_write(self._dp_id, rounded_value)
-            self._attr_native_value = rounded_value
+            # und die UI zurückspringen lassen (#77). Pending-Vergleich läuft
+            # über den rohen Wert, die Anzeige über den skalierten.
+            self._note_pending_write(self._dp_id, raw_value)
+            self._attr_native_value = (
+                raw_value / (10**self._scale) if self._scale > 0 else raw_value
+            )
             self.async_write_ha_state()
             self._schedule_write_refresh()
         except (FairlandApiClientCommunicationError, FairlandApiClientError) as ex:

--- a/custom_components/fairland/select.py
+++ b/custom_components/fairland/select.py
@@ -22,7 +22,12 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import slugify
 
 from .api import FairlandApiClientCommunicationError, FairlandApiClientError
-from .const import DOMAIN, LOGGER, WATER_PUMP_CATEGORY_CODE
+from .const import (
+    DOMAIN,
+    LOGGER,
+    SALT_MACHINE_CATEGORY_CODE,
+    WATER_PUMP_CATEGORY_CODE,
+)
 from .entity import FairlandEntity
 
 if TYPE_CHECKING:
@@ -52,6 +57,53 @@ WATER_PUMP_MODE_FALLBACK_INT_TO_OPTION: dict[int, str] = {
     0: "manual_inverter",
     1: "backwash",
 }
+
+
+# Inverter salt chlorinator (saltMachine) enum controls (issue #80). The
+# int → option map is parsed from each dp's dpProperty; `label_to_option`
+# gives firmware labels a translated option name, anything else falls through
+# to slugify so unknown firmware variants still produce a working entity.
+SALT_MACHINE_SELECT_TYPES: dict[str, dict[str, Any]] = {
+    "132": {
+        "translation_key": "salt_machine_mode",
+        "icon": "mdi:tune",
+        "label_to_option": {
+            "inverter": "inverter",
+            "auto_ph": "auto_ph",
+            "manual": "manual",
+        },
+    },
+    "122": {
+        "translation_key": "salt_polarity_reversal",
+        "icon": "mdi:swap-horizontal-bold",
+        "label_to_option": {
+            "2": "2_hours",
+            "4": "4_hours",
+            "6": "6_hours",
+        },
+    },
+}
+
+
+def _parse_enum_options(
+    dp: dict[str, Any], label_to_option: dict[str, str]
+) -> dict[int, str]:
+    """Build an enum int → option-name map from a dp's dpProperty."""
+    try:
+        prop = json.loads(dp.get("dpProperty") or "")
+    except (TypeError, ValueError):
+        prop = None
+    if not isinstance(prop, dict):
+        return {}
+
+    options: dict[int, str] = {}
+    for raw_value, label in prop.items():
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            continue
+        options[value] = label_to_option.get(str(label), slugify(str(label)))
+    return options
 
 
 def _parse_mode_options(dp: dict[str, Any]) -> dict[int, str]:
@@ -89,20 +141,33 @@ async def async_setup_entry(
 
     entities = []
     for device_info in entry.runtime_data.coordinator.data:
-        if device_info.get("categoryCode") != WATER_PUMP_CATEGORY_CODE:
-            continue
         if "dps" not in device_info:
             continue
-        if not any(
-            dp.get("dpId") == WATER_PUMP_MODE_DP_ID for dp in device_info["dps"]
-        ):
-            continue
-        entities.append(
-            FairlandWaterPumpModeSelect(
-                coordinator=entry.runtime_data.coordinator,
-                device_info=device_info,
-            )
-        )
+        category = device_info.get("categoryCode")
+
+        if category == WATER_PUMP_CATEGORY_CODE:
+            if any(
+                dp.get("dpId") == WATER_PUMP_MODE_DP_ID for dp in device_info["dps"]
+            ):
+                entities.append(
+                    FairlandWaterPumpModeSelect(
+                        coordinator=entry.runtime_data.coordinator,
+                        device_info=device_info,
+                    )
+                )
+        elif category == SALT_MACHINE_CATEGORY_CODE:
+            dp_ids = {dp.get("dpId") for dp in device_info["dps"]}
+            for dp_id, config in SALT_MACHINE_SELECT_TYPES.items():
+                if dp_id not in dp_ids:
+                    continue
+                entities.append(
+                    FairlandDpSelect(
+                        coordinator=entry.runtime_data.coordinator,
+                        device_info=device_info,
+                        dp_id=dp_id,
+                        config=config,
+                    )
+                )
     async_add_entities(entities, True)
 
 
@@ -182,6 +247,108 @@ class FairlandWaterPumpModeSelect(FairlandEntity, SelectEntity):
             self._schedule_write_refresh()
         except (FairlandApiClientCommunicationError, FairlandApiClientError) as ex:
             LOGGER.error("Error setting mode: %s", ex)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_coordinator_update)
+        )
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        for device in self.coordinator.data:
+            if device["id"] == self._device_id:
+                self._device_info = device
+                self._update_state()
+                self.async_write_ha_state()
+                break
+
+    async def async_update(self) -> None:
+        """Update the entity."""
+        await self.coordinator.async_request_refresh()
+
+
+class FairlandDpSelect(FairlandEntity, SelectEntity):
+    """Generic dpProperty-driven enum select (saltMachine controls, #80)."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: FairlandDataUpdateCoordinator,
+        device_info: dict[str, Any],
+        dp_id: str,
+        config: dict[str, Any],
+    ) -> None:
+        """Initialize the select entity."""
+        super().__init__(coordinator)
+
+        self._device_info = device_info
+        self._device_id = device_info["id"]
+        self._dp_id = dp_id
+        self._label_to_option = config.get("label_to_option", {})
+        self._int_to_option: dict[int, str] = {}
+        self._option_to_int: dict[str, int] = {}
+
+        self._attr_icon = config.get("icon")
+        self._attr_translation_key = config.get("translation_key")
+        self._attr_unique_id = f"{DOMAIN}_{self._device_id}_select_{dp_id}"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_info["deviceName"],
+            manufacturer="Fairland",
+            model=device_info.get("deviceName", "Unknown"),
+            sw_version=device_info.get("version", "Unknown"),
+        )
+
+        self._update_state()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    def _update_state(self) -> None:
+        """Update options and current option from device data."""
+        if "dps" not in self._device_info:
+            return
+        for dp in self._device_info["dps"]:
+            if dp["dpId"] == self._dp_id:
+                self._int_to_option = _parse_enum_options(dp, self._label_to_option)
+                self._option_to_int = {v: k for k, v in self._int_to_option.items()}
+                self._attr_options = list(self._int_to_option.values())
+                raw = self._effective_dp_value(self._dp_id, dp.get("dpValue"))
+                try:
+                    self._attr_current_option = self._int_to_option.get(int(raw))
+                except (TypeError, ValueError):
+                    self._attr_current_option = None
+                self._attr_available = self._attr_current_option is not None
+                return
+        self._attr_available = False
+
+    async def async_select_option(self, option: str) -> None:
+        """Write a new option to the device."""
+        if option not in self._option_to_int:
+            LOGGER.error(
+                "Refusing to set unknown option %r on dp %s", option, self._dp_id
+            )
+            return
+        target_int = self._option_to_int[option]
+        try:
+            await self.coordinator.config_entry.runtime_data.client.set_device_status(
+                self._device_id,
+                self._dp_id,
+                target_int,
+            )
+            # Optimistisch setzen; die Cloud meldet den neuen Wert erst nach
+            # 2-4 s zurück (#77).
+            self._note_pending_write(self._dp_id, target_int)
+            self._attr_current_option = option
+            self.async_write_ha_state()
+            self._schedule_write_refresh()
+        except (FairlandApiClientCommunicationError, FairlandApiClientError) as ex:
+            LOGGER.error("Error setting option on dp %s: %s", self._dp_id, ex)
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""

--- a/custom_components/fairland/select.py
+++ b/custom_components/fairland/select.py
@@ -18,7 +18,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.util import slugify
 
 from .api import FairlandApiClientCommunicationError, FairlandApiClientError
@@ -26,6 +26,7 @@ from .const import (
     DOMAIN,
     LOGGER,
     SALT_MACHINE_CATEGORY_CODE,
+    SAND_CYLINDER_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
 )
 from .entity import FairlandEntity
@@ -83,6 +84,60 @@ SALT_MACHINE_SELECT_TYPES: dict[str, dict[str, Any]] = {
         },
     },
 }
+
+
+# Multiport valve / sand-filter controller (sandCylinder, #80/#81) enum
+# controls. Their dpProperty labels are localized (Chinese on this firmware),
+# so they map by the integer key via `int_to_option` rather than by label.
+# Option names taken from the firmware's own en-US propNameLanguage.
+SAND_CYLINDER_SELECT_TYPES: dict[str, dict[str, Any]] = {
+    "106": {
+        "translation_key": "sand_cylinder_mode",
+        "icon": "mdi:valve",
+        "int_to_option": {
+            0: "no_movement",
+            1: "one_touch_rinse",
+            2: "recirc",
+            3: "closed",
+            4: "filter",
+            5: "waste",
+        },
+    },
+    "125": {
+        "translation_key": "sand_cylinder_pump_control",
+        "icon": "mdi:water-pump",
+        "int_to_option": {0: "none", 1: "pump_on", 2: "pump_off"},
+    },
+    "118": {
+        "translation_key": "sand_cylinder_pressure_unit",
+        "icon": "mdi:gauge",
+        "entity_category": EntityCategory.CONFIG,
+        "int_to_option": {0: "mpa", 1: "kpa", 2: "psi", 3: "bar"},
+    },
+    "123": {
+        "translation_key": "sand_cylinder_temp_detection",
+        "icon": "mdi:thermometer",
+        "entity_category": EntityCategory.CONFIG,
+        "int_to_option": {0: "off", 1: "celsius", 2: "fahrenheit"},
+    },
+}
+
+
+def _enum_int_keys(dp: dict[str, Any]) -> set[int]:
+    """Return the set of integer enum keys advertised in a dp's dpProperty."""
+    try:
+        prop = json.loads(dp.get("dpProperty") or "")
+    except (TypeError, ValueError):
+        return set()
+    if not isinstance(prop, dict):
+        return set()
+    keys: set[int] = set()
+    for raw_value in prop:
+        try:
+            keys.add(int(raw_value))
+        except (TypeError, ValueError):
+            continue
+    return keys
 
 
 def _parse_enum_options(
@@ -155,9 +210,14 @@ async def async_setup_entry(
                         device_info=device_info,
                     )
                 )
-        elif category == SALT_MACHINE_CATEGORY_CODE:
+        elif category in (SALT_MACHINE_CATEGORY_CODE, SAND_CYLINDER_CATEGORY_CODE):
+            select_types = (
+                SALT_MACHINE_SELECT_TYPES
+                if category == SALT_MACHINE_CATEGORY_CODE
+                else SAND_CYLINDER_SELECT_TYPES
+            )
             dp_ids = {dp.get("dpId") for dp in device_info["dps"]}
-            for dp_id, config in SALT_MACHINE_SELECT_TYPES.items():
+            for dp_id, config in select_types.items():
                 if dp_id not in dp_ids:
                     continue
                 entities.append(
@@ -287,11 +347,15 @@ class FairlandDpSelect(FairlandEntity, SelectEntity):
         self._device_id = device_info["id"]
         self._dp_id = dp_id
         self._label_to_option = config.get("label_to_option", {})
+        # When given, the enum is mapped by its integer key (firmware labels
+        # may be localized); otherwise it is parsed from the dpProperty labels.
+        self._int_to_option_override = config.get("int_to_option")
         self._int_to_option: dict[int, str] = {}
         self._option_to_int: dict[str, int] = {}
 
         self._attr_icon = config.get("icon")
         self._attr_translation_key = config.get("translation_key")
+        self._attr_entity_category = config.get("entity_category")
         self._attr_unique_id = f"{DOMAIN}_{self._device_id}_select_{dp_id}"
 
         self._attr_device_info = DeviceInfo(
@@ -315,7 +379,15 @@ class FairlandDpSelect(FairlandEntity, SelectEntity):
             return
         for dp in self._device_info["dps"]:
             if dp["dpId"] == self._dp_id:
-                self._int_to_option = _parse_enum_options(dp, self._label_to_option)
+                if self._int_to_option_override is not None:
+                    valid = _enum_int_keys(dp)
+                    self._int_to_option = {
+                        i: opt
+                        for i, opt in self._int_to_option_override.items()
+                        if not valid or i in valid
+                    }
+                else:
+                    self._int_to_option = _parse_enum_options(dp, self._label_to_option)
                 self._option_to_int = {v: k for k, v in self._int_to_option.items()}
                 self._attr_options = list(self._int_to_option.values())
                 raw = self._effective_dp_value(self._dp_id, dp.get("dpValue"))

--- a/custom_components/fairland/sensor.py
+++ b/custom_components/fairland/sensor.py
@@ -12,6 +12,8 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfPower,
     UnitOfTemperature,
@@ -23,6 +25,7 @@ from .const import (
     DOMAIN,
     HEAT_PUMP_CATEGORY_CODE,
     LOGGER,
+    SALT_MACHINE_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
 )
 from .entity import FairlandEntity
@@ -325,6 +328,125 @@ WATER_PUMP_SENSOR_TYPES = {
 }
 
 
+# Inverter salt chlorinator (saltMachine) read-only data points (issue #80).
+# dpProperty is the source of truth for scale, so the scale-from-property
+# path in async_setup_entry fills it in (pH and several electrical values
+# arrive as integers × 10). Enum points (`is_enum`) map their integer value
+# to the firmware-reported labels; the raw display point (128) is shown
+# verbatim as text.
+SALT_MACHINE_SENSOR_TYPES = {
+    "101": {
+        "name": "Salt Concentration",
+        "unit": "ppm",
+        "icon": "mdi:shaker-outline",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "112": {
+        "name": "pH",
+        "unit": None,
+        "icon": "mdi:ph",
+        "device_class": SensorDeviceClass.PH,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "111": {
+        "name": "ORP",
+        "unit": UnitOfElectricPotential.MILLIVOLT,
+        "icon": "mdi:test-tube",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    # dp 102 = pool water temperature (°C); dp 133 mirrors it in °F. dp 105 is
+    # the controller's internal/housing temperature.
+    "102": {
+        "name": "Pool Water Temperature",
+        "unit": UnitOfTemperature.CELSIUS,
+        "icon": "mdi:pool-thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "133": {
+        "name": "Pool Water Temperature (°F)",
+        "unit": UnitOfTemperature.FAHRENHEIT,
+        "icon": "mdi:pool-thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "105": {
+        "name": "Controller Temperature",
+        "unit": UnitOfTemperature.CELSIUS,
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "113": {
+        "name": "Chlorine Output",
+        "unit": PERCENTAGE,
+        "icon": "mdi:gauge",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "124": {
+        "name": "Power",
+        "unit": UnitOfPower.WATT,
+        "icon": "mdi:flash",
+        "device_class": SensorDeviceClass.POWER,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "106": {
+        "name": "Voltage",
+        "unit": UnitOfElectricPotential.VOLT,
+        "icon": "mdi:sine-wave",
+        "device_class": SensorDeviceClass.VOLTAGE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "130": {
+        "name": "Current",
+        "unit": UnitOfElectricCurrent.AMPERE,
+        "icon": "mdi:current-ac",
+        "device_class": SensorDeviceClass.CURRENT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "145": {
+        "name": "Runtime",
+        "unit": UnitOfTime.HOURS,
+        "icon": "mdi:timer-outline",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "119": {
+        "name": "Water Quality",
+        "unit": None,
+        "icon": "mdi:water-check",
+        "device_class": SensorDeviceClass.ENUM,
+        "state_class": None,
+        "is_enum": True,
+    },
+    "127": {
+        "name": "Active Profile",
+        "unit": None,
+        "icon": "mdi:cog-outline",
+        "device_class": SensorDeviceClass.ENUM,
+        "state_class": None,
+        "is_enum": True,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "128": {
+        "name": "Display",
+        "unit": None,
+        "icon": "mdi:dock-window",
+        "device_class": None,
+        "state_class": None,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+}
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: FairlandConfigEntry,
@@ -345,6 +467,8 @@ async def async_setup_entry(
             sensor_types = HEAT_PUMP_SENSOR_TYPES
         elif category == WATER_PUMP_CATEGORY_CODE:
             sensor_types = WATER_PUMP_SENSOR_TYPES
+        elif category == SALT_MACHINE_CATEGORY_CODE:
+            sensor_types = SALT_MACHINE_SENSOR_TYPES
         else:
             continue
 
@@ -381,6 +505,18 @@ async def async_setup_entry(
                     ):
                         sensor_config = sensor_config.copy()
                         sensor_config["unit"] = DP_PROPERTY_TIME_UNITS[prop["unit"]]
+                    # Enum-Sensoren: die Firmware liefert die Wert→Label-Map
+                    # direkt in dpProperty (z.B. {"0": "WAIT", "1": "GOOD"}).
+                    if sensor_config.get("is_enum"):
+                        enum_map = {
+                            str(k): str(v)
+                            for k, v in prop.items()
+                            if str(k).lstrip("-").isdigit()
+                        }
+                        if enum_map:
+                            sensor_config = sensor_config.copy()
+                            sensor_config["enum_map"] = enum_map
+                            sensor_config["options"] = list(enum_map.values())
                 except (json.JSONDecodeError, KeyError, ValueError) as ex:
                     LOGGER.warning(
                         "Failed to parse dpProperty for dp %s: %s", dp_id, ex
@@ -423,6 +559,9 @@ class FairlandSensor(FairlandEntity, SensorEntity):
         self._dp_id = dp_id
         self._sensor_config = sensor_config
         self._scale = sensor_config.get("scale", 0)
+        # Enum sensors map the raw integer value to a firmware label
+        # ({"0": "WAIT", ...}); when set, scaling is skipped.
+        self._enum_map = sensor_config.get("enum_map")
 
         # Set attributes based on sensor_config
         self._attr_name = sensor_config["name"]
@@ -432,6 +571,8 @@ class FairlandSensor(FairlandEntity, SensorEntity):
         self._attr_device_class = sensor_config.get("device_class")
         self._attr_state_class = sensor_config.get("state_class")
         self._attr_entity_category = sensor_config.get("entity_category")
+        if "options" in sensor_config:
+            self._attr_options = sensor_config["options"]
 
         # Device info
         self._attr_device_info = DeviceInfo(
@@ -457,6 +598,16 @@ class FairlandSensor(FairlandEntity, SensorEntity):
         """Return if entity is available."""
         return self.coordinator.last_update_success
 
+    def _present_value(self, value: Any) -> Any:
+        """Map a raw dpValue to its presented value (enum label or scaled)."""
+        if value is None:
+            return None
+        if self._enum_map is not None:
+            return self._enum_map.get(str(value), value)
+        if self._scale > 0:
+            return value / (10**self._scale)
+        return value
+
     def _update_state(self):
         """Update state from device data."""
         if "dps" in self._device_info:
@@ -464,28 +615,11 @@ class FairlandSensor(FairlandEntity, SensorEntity):
             dp_map = {item["dpId"]: item for item in self._device_info["dps"]}
 
             if self._dp_id in dp_map:
-                value = dp_map[self._dp_id]["dpValue"]
-
-                # Skalierung anwenden (z.B. für Leistung)
-                if self._scale > 0 and value is not None:
-                    value = value / (10**self._scale)
-
-                self._attr_native_value = value
+                self._attr_native_value = self._present_value(
+                    dp_map[self._dp_id]["dpValue"]
+                )
                 self._attr_available = True
                 return
-
-            # ist die logik nicht doppelt?!?!
-            for dp in self._device_info["dps"]:
-                if dp["dpId"] == self._dp_id:
-                    value = dp["dpValue"]
-
-                    # Skalierung anwenden
-                    if self._scale > 0 and value is not None:
-                        value = value / (10**self._scale)
-
-                    self._attr_native_value = value
-                    self._attr_available = True
-                    return
 
             # Wenn wir den Datenpunkt nicht gefunden haben
             LOGGER.warning(

--- a/custom_components/fairland/sensor.py
+++ b/custom_components/fairland/sensor.py
@@ -26,6 +26,7 @@ from .const import (
     HEAT_PUMP_CATEGORY_CODE,
     LOGGER,
     SALT_MACHINE_CATEGORY_CODE,
+    SAND_CYLINDER_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
 )
 from .entity import FairlandEntity
@@ -447,6 +448,53 @@ SALT_MACHINE_SENSOR_TYPES = {
 }
 
 
+# Multiport valve / sand-filter controller (sandCylinder, #80/#81). Names are
+# taken verbatim from the firmware's own nameLanguage (en-US). Pressures are
+# reported in MPa; HA has no MPa pressure unit, so they ride as a plain unit
+# string without a device_class. dp 107 carries English enum labels in its
+# dpProperty, so it maps via the generic is_enum path.
+SAND_CYLINDER_SENSOR_TYPES = {
+    "101": {
+        "name": "Water Temperature",
+        "unit": UnitOfTemperature.CELSIUS,
+        "icon": "mdi:thermometer-water",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "102": {
+        "name": "Pressure",
+        "unit": "MPa",
+        "icon": "mdi:gauge",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "107": {
+        "name": "Valve Position",
+        "unit": None,
+        "icon": "mdi:pipe-valve",
+        "device_class": SensorDeviceClass.ENUM,
+        "state_class": None,
+        "is_enum": True,
+    },
+    "115": {
+        "name": "Timed Backwash Remaining",
+        "unit": UnitOfTime.DAYS,
+        "icon": "mdi:calendar-clock",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "116": {
+        "name": "Rinse Countdown",
+        "unit": UnitOfTime.SECONDS,
+        "icon": "mdi:timer-sand",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+}
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: FairlandConfigEntry,
@@ -469,6 +517,8 @@ async def async_setup_entry(
             sensor_types = WATER_PUMP_SENSOR_TYPES
         elif category == SALT_MACHINE_CATEGORY_CODE:
             sensor_types = SALT_MACHINE_SENSOR_TYPES
+        elif category == SAND_CYLINDER_CATEGORY_CODE:
+            sensor_types = SAND_CYLINDER_SENSOR_TYPES
         else:
             continue
 

--- a/custom_components/fairland/switch.py
+++ b/custom_components/fairland/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.entity import DeviceInfo
 
 from .api import FairlandApiClientCommunicationError, FairlandApiClientError
@@ -12,6 +12,7 @@ from .const import (
     DOMAIN,
     HEAT_PUMP_CATEGORY_CODE,
     LOGGER,
+    SALT_MACHINE_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
 )
 from .entity import FairlandEntity
@@ -23,19 +24,47 @@ if TYPE_CHECKING:
     from .coordinator import FairlandDataUpdateCoordinator
     from .data import FairlandConfigEntry
 
-ENTITY_DESCRIPTIONS = (
-    SwitchEntityDescription(
-        key="Fairland",
-        name="Power",
-        icon="mdi:power",
-    ),
-)
+# Per-category switch maps. Each entry maps a dpId to its presentation.
+# `is_power` marks the device's main power switch, which keeps the original
+# `_switch` unique_id for backwards compatibility; every other switch gets a
+# `_switch_<dpId>` suffix. `require_value` skips creation when the firmware
+# never populates the dp (always null).
+#
+# Power dpId differs per category: heat pumps use dpId 101, water pumps use
+# dpId 105 (dpId 105 is the "Running Percentage" sensor on heat pumps, so the
+# maps must stay separate), salt chlorinators use dpId 103.
+HEAT_PUMP_SWITCH_TYPES: dict[str, dict[str, Any]] = {
+    "101": {"name": "Power", "icon": "mdi:power", "is_power": True},
+}
+WATER_PUMP_SWITCH_TYPES: dict[str, dict[str, Any]] = {
+    "105": {"name": "Power", "icon": "mdi:power", "is_power": True},
+}
+SALT_MACHINE_SWITCH_TYPES: dict[str, dict[str, Any]] = {
+    "103": {"name": "Power", "icon": "mdi:power", "is_power": True},
+    "107": {"name": "Turbo", "icon": "mdi:rocket-launch"},
+    "121": {"name": "Timer", "icon": "mdi:timer-cog"},
+    "123": {"name": "Real-time Salinity Monitoring", "icon": "mdi:shaker-outline"},
+    # Backwash: rw, but null on firmwares without it. Useful for automations
+    # (pausing chlorine production during a backwash cycle).
+    "153": {"name": "Backwash", "icon": "mdi:water-sync", "require_value": True},
+}
 
-# Power dpId differs per category: heat pumps use dpId 101, water pumps
-# use dpId 105. They cannot share a fixed constant because dpId 105 is the
-# "Running Percentage" diagnostic sensor on heat pumps.
-HEAT_PUMP_POWER_DP_ID = "101"
-WATER_PUMP_POWER_DP_ID = "105"
+CATEGORY_SWITCH_TYPES = {
+    HEAT_PUMP_CATEGORY_CODE: HEAT_PUMP_SWITCH_TYPES,
+    WATER_PUMP_CATEGORY_CODE: WATER_PUMP_SWITCH_TYPES,
+    SALT_MACHINE_CATEGORY_CODE: SALT_MACHINE_SWITCH_TYPES,
+}
+
+
+def _coerce_bool(raw: Any) -> bool:
+    """Coerce a dpValue (bool / 0|1 / "0"|"1"|"on") to a switch state."""
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return raw != 0
+    if isinstance(raw, str):
+        return raw.strip().lower() in ("1", "true", "on", "yes")
+    return bool(raw)
 
 
 async def async_setup_entry(
@@ -47,40 +76,29 @@ async def async_setup_entry(
     LOGGER.debug("Setting up Fairland switch platform")
 
     entities = []
-    devices = entry.runtime_data.coordinator.data
+    for device_info in entry.runtime_data.coordinator.data:
+        switch_types = CATEGORY_SWITCH_TYPES.get(device_info.get("categoryCode"))
+        if switch_types is None:
+            continue
 
-    for device_info in devices:
-        category = device_info.get("categoryCode")
-        if category == HEAT_PUMP_CATEGORY_CODE:
-            LOGGER.debug("Found heat pump device: %s", device_info["deviceName"])
-            entities.append(
-                FairlandSwitch(
-                    coordinator=entry.runtime_data.coordinator,
-                    device_info=device_info,
-                    entity_description=ENTITY_DESCRIPTIONS,
-                    power_dp_id=HEAT_PUMP_POWER_DP_ID,
-                )
-            )
-        elif category == WATER_PUMP_CATEGORY_CODE:
-            # Skip water pumps that don't expose the power dpId at all
-            # (defensive — every firmware seen so far exposes 105).
-            if not _has_dp(device_info, WATER_PUMP_POWER_DP_ID):
+        dp_map = {dp.get("dpId"): dp for dp in device_info.get("dps", [])}
+        for dp_id, config in switch_types.items():
+            if dp_id not in dp_map:
                 continue
-            LOGGER.debug("Found water pump device: %s", device_info["deviceName"])
+            if config.get("require_value") and dp_map[dp_id].get("dpValue") is None:
+                LOGGER.debug(
+                    "Skipping switch dp %s: firmware does not populate it", dp_id
+                )
+                continue
             entities.append(
                 FairlandSwitch(
                     coordinator=entry.runtime_data.coordinator,
                     device_info=device_info,
-                    entity_description=ENTITY_DESCRIPTIONS,
-                    power_dp_id=WATER_PUMP_POWER_DP_ID,
+                    dp_id=dp_id,
+                    config=config,
                 )
             )
     async_add_entities(entities, True)
-
-
-def _has_dp(device_info: dict[str, Any], dp_id: str) -> bool:
-    """Return True if device_info advertises the given dpId."""
-    return any(dp.get("dpId") == dp_id for dp in device_info.get("dps", []))
 
 
 class FairlandSwitch(FairlandEntity, SwitchEntity):
@@ -92,21 +110,22 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
         self,
         coordinator: FairlandDataUpdateCoordinator,
         device_info: dict[str, Any],
-        entity_description: SwitchEntityDescription,
-        power_dp_id: str = "101",
+        dp_id: str,
+        config: dict[str, Any],
     ) -> None:
         """Initialize the switch class."""
         super().__init__(coordinator)
-        LOGGER.debug("Switch device info: %s", self._attr_device_info)
-        # self.entity_description = entity_description
 
         self._device_info = device_info
         self._device_id = device_info["id"]
-        self._power_dp_id = power_dp_id
+        self._dp_id = dp_id
 
-        self._attr_unique_id = f"{DOMAIN}_{self._device_id}_switch"
-        self._attr_name = "Power"
-        self._attr_icon = "mdi:power"
+        # Preserve the original unique_id for the main power switch so
+        # existing installs keep their entity history.
+        suffix = "switch" if config.get("is_power") else f"switch_{dp_id}"
+        self._attr_unique_id = f"{DOMAIN}_{self._device_id}_{suffix}"
+        self._attr_name = config["name"]
+        self._attr_icon = config.get("icon", "mdi:power")
         self._is_on = False
 
         # Device info
@@ -125,9 +144,9 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
         """Update state from device data."""
         if "dps" in self._device_info:
             for dp in self._device_info["dps"]:
-                if dp["dpId"] == self._power_dp_id:
-                    self._is_on = self._effective_dp_value(
-                        self._power_dp_id, dp["dpValue"]
+                if dp["dpId"] == self._dp_id:
+                    self._is_on = _coerce_bool(
+                        self._effective_dp_value(self._dp_id, dp["dpValue"])
                     )
                     self._attr_available = True
                     return
@@ -140,7 +159,6 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        LOGGER.debug("Switch available: %s", self.coordinator.last_update_success)
         return self.coordinator.last_update_success
 
     async def async_added_to_hass(self) -> None:
@@ -164,35 +182,28 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
         # The coordinator handles the updates
         await self.coordinator.async_request_refresh()
 
-    async def async_turn_on(self, **kwargs) -> None:
-        """Turn the switch on."""
+    async def _async_write(self, value: bool) -> None:
+        """Write a new on/off state, holding it optimistically (#77)."""
         try:
             await self.coordinator.config_entry.runtime_data.client.set_device_status(
                 self._device_id,
-                self._power_dp_id,
-                True,
+                self._dp_id,
+                value,
             )
             # Optimistisch setzen; die Cloud meldet den neuen Wert erst nach
             # 2-4 s zurück, ein sofortiger Refresh würde den alten Wert lesen
             # und die UI zurückspringen lassen (#77).
-            self._note_pending_write(self._power_dp_id, True)
-            self._is_on = True
+            self._note_pending_write(self._dp_id, value)
+            self._is_on = value
             self.async_write_ha_state()
             self._schedule_write_refresh()
         except (FairlandApiClientCommunicationError, FairlandApiClientError) as ex:
-            LOGGER.error("Error turning on switch: %s", ex)
+            LOGGER.error("Error setting switch %s: %s", self._dp_id, ex)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the switch on."""
+        await self._async_write(True)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
-        try:
-            await self.coordinator.config_entry.runtime_data.client.set_device_status(
-                self._device_id,
-                self._power_dp_id,
-                False,
-            )
-            self._note_pending_write(self._power_dp_id, False)
-            self._is_on = False
-            self.async_write_ha_state()
-            self._schedule_write_refresh()
-        except (FairlandApiClientCommunicationError, FairlandApiClientError) as ex:
-            LOGGER.error("Error turning off switch: %s", ex)
+        await self._async_write(False)

--- a/custom_components/fairland/translations/en.json
+++ b/custom_components/fairland/translations/en.json
@@ -48,6 +48,22 @@
           "manual_inverter": "Manual Inverter",
           "backwash": "Backwash"
         }
+      },
+      "salt_machine_mode": {
+        "name": "Mode",
+        "state": {
+          "inverter": "Inverter",
+          "auto_ph": "Auto pH",
+          "manual": "Manual"
+        }
+      },
+      "salt_polarity_reversal": {
+        "name": "Polarity Reversal Interval",
+        "state": {
+          "2_hours": "Every 2 hours",
+          "4_hours": "Every 4 hours",
+          "6_hours": "Every 6 hours"
+        }
       }
     }
   }

--- a/custom_components/fairland/translations/en.json
+++ b/custom_components/fairland/translations/en.json
@@ -64,6 +64,42 @@
           "4_hours": "Every 4 hours",
           "6_hours": "Every 6 hours"
         }
+      },
+      "sand_cylinder_mode": {
+        "name": "Mode",
+        "state": {
+          "no_movement": "No movement",
+          "one_touch_rinse": "One-touch rinse",
+          "recirc": "Recirculate",
+          "closed": "Closed",
+          "filter": "Filter",
+          "waste": "Waste"
+        }
+      },
+      "sand_cylinder_pump_control": {
+        "name": "Pump Control",
+        "state": {
+          "none": "No action",
+          "pump_on": "Turn pump on",
+          "pump_off": "Turn pump off"
+        }
+      },
+      "sand_cylinder_pressure_unit": {
+        "name": "Pressure Unit",
+        "state": {
+          "mpa": "MPa",
+          "kpa": "kPa",
+          "psi": "psi",
+          "bar": "bar"
+        }
+      },
+      "sand_cylinder_temp_detection": {
+        "name": "Temperature Detection",
+        "state": {
+          "off": "Off",
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
       }
     }
   }

--- a/diagnostics/README.md
+++ b/diagnostics/README.md
@@ -1,0 +1,37 @@
+# Local diagnostics archive
+
+Raw diagnostics JSONs that users attach to issues, kept here for reference
+when investigating device behavior or adding support for new firmwares and
+device categories.
+
+**These files are gitignored and must never be committed** — they contain
+account/device data and are large. Only this README is tracked (see the
+`diagnostics/*` rule in `.gitignore`).
+
+## Naming convention
+
+```
+issue-<NN>-<short-description>.json
+```
+
+e.g. `issue-80-salt-chlorinator.json`, `issue-77-pump-mode.json`.
+
+## Reading a dump
+
+Live device state is under the top-level `data.devices` key (coordinator
+data). `data.entry_data` is config only. Each device has a `categoryCode`
+(`heatPump` / `waterPump` / `saltMachine` / …) and a `dps` list; each dp
+carries `dpId`, `dpValue`, `dpProperty` (scale/min/max/unit/enum labels —
+the firmware-specific source of truth), `dpMode` (`ro`/`rw`/`wo`) and
+`dpType`.
+
+## Promoting a dump to a test fixture
+
+When a dump informs a code change, turn it into a small committed fixture so
+the behavior is regression-tested (see `tests/` and CLAUDE.md → "Verifying
+Against Real Devices"):
+
+1. Pick one representative device from `data.devices`.
+2. Keep only `dpId`, `dpValue`, `dpProperty`, `dpMode`, `dpType` per dp.
+3. Anonymize `id` and `deviceName`.
+4. Write it to `tests/fixtures/<category>.json` and add a test.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+# Test dependencies. The stub-based suite under tests/ does not import Home
+# Assistant (see tests/conftest.py), so pytest is all that is needed.
+pytest==9.1.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,247 @@
+"""Test harness for the Fairland integration platforms.
+
+Home Assistant is not installed for the test run. Instead we stub the
+``homeassistant.*`` modules (and ``aiohttp``) in ``sys.modules`` with the
+minimal surface each platform touches, then load the integration's platform
+files via importlib. Tests feed real (sanitized) device dicts from the
+diagnostics fixtures and assert which entities are created and how their
+values/units/scales come out. See CLAUDE.md ("Verifying Against Real
+Devices") for the rationale.
+
+Limitation: the stubs are intentionally permissive, so these tests verify dp
+mapping (scale, units, polarity, category dispatch) but cannot catch misuse
+of the real Home Assistant entity API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "fairland"
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+# --------------------------------------------------------------------------
+# Stub homeassistant.* and aiohttp
+# --------------------------------------------------------------------------
+class _AttrStr:
+    """Enum stand-in: attribute access returns the attribute name."""
+
+    def __getattr__(self, name: str) -> str:
+        return name
+
+
+def _register(name: str, **attrs) -> types.ModuleType:
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+class _CoordinatorEntity:
+    """Minimal CoordinatorEntity: stores the coordinator, no-ops the rest."""
+
+    hass = None
+
+    def __init__(self, coordinator) -> None:
+        self.coordinator = coordinator
+
+    def __class_getitem__(cls, item):  # CoordinatorEntity[Coordinator]
+        return cls
+
+    def async_on_remove(self, *args, **kwargs) -> None:
+        pass
+
+    def async_write_ha_state(self) -> None:
+        pass
+
+    def schedule_update_ha_state(self, *args, **kwargs) -> None:
+        pass
+
+
+def _device_info(**kwargs) -> dict:
+    return dict(kwargs)
+
+
+def _slugify(value) -> str:
+    return "".join(c if c.isalnum() else "_" for c in str(value).lower()).strip("_")
+
+
+def _install_stubs() -> None:
+    _register("aiohttp", ClientSession=object, ClientError=Exception)
+    _register("homeassistant")
+    _register(
+        "homeassistant.const",
+        PERCENTAGE="%",
+        UnitOfElectricCurrent=_AttrStr(),
+        UnitOfElectricPotential=_AttrStr(),
+        UnitOfEnergy=_AttrStr(),
+        UnitOfPower=_AttrStr(),
+        UnitOfTemperature=_AttrStr(),
+        UnitOfTime=_AttrStr(),
+        CONF_PASSWORD="password",
+        CONF_USERNAME="username",
+        Platform=_AttrStr(),
+    )
+    _register("homeassistant.core", HomeAssistant=object)
+    _register("homeassistant.util", slugify=_slugify)
+    _register(
+        "homeassistant.components.sensor",
+        SensorDeviceClass=_AttrStr(),
+        SensorEntity=type("SensorEntity", (), {}),
+        SensorStateClass=_AttrStr(),
+    )
+    _register(
+        "homeassistant.components.switch",
+        SwitchEntity=type("SwitchEntity", (), {}),
+    )
+    _register(
+        "homeassistant.components.select",
+        SelectEntity=type("SelectEntity", (), {}),
+    )
+    _register(
+        "homeassistant.components.number",
+        NumberDeviceClass=_AttrStr(),
+        NumberEntity=type("NumberEntity", (), {}),
+        NumberMode=_AttrStr(),
+    )
+    _register(
+        "homeassistant.components.binary_sensor",
+        BinarySensorDeviceClass=_AttrStr(),
+        BinarySensorEntity=type("BinarySensorEntity", (), {}),
+    )
+    _register("homeassistant.helpers")
+    _register(
+        "homeassistant.helpers.entity",
+        DeviceInfo=_device_info,
+        EntityCategory=_AttrStr(),
+    )
+    _register("homeassistant.helpers.device_registry", DeviceInfo=_device_info)
+    _register(
+        "homeassistant.helpers.update_coordinator",
+        CoordinatorEntity=_CoordinatorEntity,
+        DataUpdateCoordinator=type("DataUpdateCoordinator", (), {}),
+        UpdateFailed=type("UpdateFailed", (Exception,), {}),
+    )
+    _register(
+        "homeassistant.helpers.event",
+        async_call_later=lambda *a, **k: lambda: None,
+    )
+    _register("homeassistant.helpers.entity_platform", AddEntitiesCallback=object)
+    _register(
+        "homeassistant.helpers.aiohttp_client",
+        async_get_clientsession=lambda *a, **k: None,
+    )
+    _register("homeassistant.loader", async_get_loaded_integration=lambda *a, **k: None)
+
+
+def _load_integration() -> dict[str, types.ModuleType]:
+    package = types.ModuleType("fairland")
+    package.__path__ = [str(PKG_DIR)]
+    sys.modules["fairland"] = package
+
+    def load(name: str) -> types.ModuleType:
+        spec = importlib.util.spec_from_file_location(
+            f"fairland.{name}", PKG_DIR / f"{name}.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[f"fairland.{name}"] = module
+        spec.loader.exec_module(module)
+        return module
+
+    # Dependency order: leaves first.
+    for name in ("const", "api", "data", "coordinator", "entity"):
+        load(name)
+    return {
+        name: load(name)
+        for name in ("sensor", "switch", "select", "number", "binary_sensor")
+    }
+
+
+_install_stubs()
+_PLATFORMS = _load_integration()
+
+
+# --------------------------------------------------------------------------
+# Fake coordinator / config entry plumbing
+# --------------------------------------------------------------------------
+class FakeClient:
+    """Records set_device_status calls so write paths can be asserted."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def set_device_status(self, device_id, dp_id, value):
+        self.calls.append((device_id, dp_id, value))
+
+
+class _FakeConfigEntry:
+    domain = "fairland"
+    entry_id = "test_entry"
+
+
+class _FakeRuntime:
+    def __init__(self, coordinator, client) -> None:
+        self.coordinator = coordinator
+        self.client = client
+
+
+class _FakeCoordinator:
+    def __init__(self, devices, client) -> None:
+        self.data = devices
+        self.last_update_success = True
+        self.config_entry = _FakeConfigEntry()
+        self.config_entry.runtime_data = _FakeRuntime(self, client)
+
+    def async_add_listener(self, *args, **kwargs):
+        return lambda: None
+
+    async def async_request_refresh(self) -> None:
+        pass
+
+
+class _FakeEntry:
+    def __init__(self, coordinator, client) -> None:
+        self.runtime_data = _FakeRuntime(coordinator, client)
+
+
+# --------------------------------------------------------------------------
+# Fixtures / helpers
+# --------------------------------------------------------------------------
+def load_fixture(name: str) -> list[dict]:
+    """Return the device list from a fixture file as a single-device list."""
+    data = json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+    return data if isinstance(data, list) else [data]
+
+
+@pytest.fixture
+def platforms() -> dict[str, types.ModuleType]:
+    return _PLATFORMS
+
+
+@pytest.fixture
+def setup_entities():
+    """Return a helper: (platform_name, devices) -> (entities, client)."""
+
+    def _run(platform_name: str, devices: list[dict]):
+        client = FakeClient()
+        coordinator = _FakeCoordinator(devices, client)
+        entry = _FakeEntry(coordinator, client)
+        collected: list = []
+
+        def _add(entities, *args, **kwargs):
+            collected.extend(entities)
+
+        asyncio.run(_PLATFORMS[platform_name].async_setup_entry(None, entry, _add))
+        return collected, client
+
+    return _run

--- a/tests/fixtures/salt_machine.json
+++ b/tests/fixtures/salt_machine.json
@@ -1,0 +1,267 @@
+{
+  "id": "1000000000000000001",
+  "deviceName": "Test Salt Chlorinator",
+  "categoryCode": "saltMachine",
+  "version": null,
+  "dps": [
+    {
+      "dpId": "101",
+      "dpValue": 3018,
+      "dpProperty": "{\"max\": 10000, \"min\": 0, \"init\": 0, \"step\": 1, \"unit\": \"ppm\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "102",
+      "dpValue": 150,
+      "dpProperty": "{\"max\": 1000, \"min\": -1000, \"init\": 0, \"step\": 1, \"unit\": \"℃\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "103",
+      "dpValue": true,
+      "dpProperty": "{\"true\": \"开\", \"false\": \"关\"}",
+      "dpMode": "rw",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "104",
+      "dpValue": false,
+      "dpProperty": "{\"true\": \"℉\", \"false\": \"℃\"}",
+      "dpMode": "rw",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "105",
+      "dpValue": 204,
+      "dpProperty": "{\"max\": 1000, \"min\": -1000, \"init\": 0, \"step\": 1, \"unit\": \"℃\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "106",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 5000, \"min\": 0, \"init\": 0, \"step\": 1, \"unit\": \"V\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "107",
+      "dpValue": false,
+      "dpProperty": "{\"true\": \"开\", \"false\": \"关\"}",
+      "dpMode": "rw",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "108",
+      "dpValue": 650,
+      "dpProperty": "{\"max\": 850, \"min\": 200, \"init\": 200, \"step\": 10, \"unit\": \"mV\", \"scale\": 0}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "109",
+      "dpValue": 100,
+      "dpProperty": "{\"max\": 100, \"min\": 5, \"init\": 5, \"step\": 5, \"unit\": \"m³\", \"scale\": 0}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "110",
+      "dpValue": 74,
+      "dpProperty": "{\"max\": 85, \"min\": 65, \"init\": 65, \"step\": 1, \"scale\": 1}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "111",
+      "dpValue": 710,
+      "dpProperty": "{\"max\": 2000, \"min\": -2000, \"init\": 0, \"step\": 1, \"unit\": \"mV\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "112",
+      "dpValue": 69,
+      "dpProperty": "{\"max\": 140, \"min\": 0, \"init\": 0, \"step\": 1, \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "113",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 200, \"min\": 0, \"init\": 0, \"step\": 1, \"unit\": \"%\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "114",
+      "dpValue": null,
+      "dpProperty": "{\"true\": \"有水流\", \"false\": \"无水流\"}",
+      "dpMode": "ro",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "115",
+      "dpValue": null,
+      "dpProperty": "{\"true\": \"加酸\", \"false\": \"不加酸\"}",
+      "dpMode": "ro",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "116",
+      "dpValue": null,
+      "dpProperty": "{\"true\": \"校准\", \"false\": \"不校准\"}",
+      "dpMode": "ro",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "117",
+      "dpValue": null,
+      "dpProperty": "{\"true\": \"加盐\", \"false\": \"不加盐\"}",
+      "dpMode": "ro",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "118",
+      "dpValue": null,
+      "dpProperty": "{\"true\": \"更换探头\", \"false\": \"不更换探头\"}",
+      "dpMode": "ro",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "119",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"WAIT\", \"1\": \"GOOD\", \"2\": \"GREAT\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "121",
+      "dpValue": false,
+      "dpProperty": "{\"true\": \"开\", \"false\": \"关\"}",
+      "dpMode": "rw",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "122",
+      "dpValue": 1,
+      "dpProperty": "{\"0\": \"2\", \"1\": \"4\", \"2\": \"6\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "123",
+      "dpValue": true,
+      "dpProperty": "{\"true\": \"开\", \"false\": \"关\"}",
+      "dpMode": "rw",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "124",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 500000, \"min\": 0, \"init\": 0, \"step\": 1, \"unit\": \"W\", \"scale\": 2}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "125",
+      "dpValue": 100,
+      "dpProperty": "{\"max\": 130, \"min\": 0, \"init\": 0, \"step\": 5, \"unit\": \"%\", \"scale\": 0}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "126",
+      "dpValue": 50,
+      "dpProperty": "{\"max\": 9990, \"min\": 0, \"init\": 0, \"step\": 10, \"unit\": \"ml/day\", \"scale\": 0}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "127",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"F1\", \"1\": \"F2\", \"2\": \"F3\", \"3\": \"F4\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "128",
+      "dpValue": "AAAA",
+      "dpProperty": "{}",
+      "dpMode": "ro",
+      "dpType": "raw"
+    },
+    {
+      "dpId": "130",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 30000, \"min\": 0, \"init\": 0, \"step\": 1, \"unit\": \"A\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "131",
+      "dpValue": 1,
+      "dpProperty": "{\"0\": \"base\", \"1\": \"Italian_water_pump\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "132",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"inverter\", \"1\": \"auto_ph\", \"3\": \"manual\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "133",
+      "dpValue": 590,
+      "dpProperty": "{\"max\": 2120, \"min\": -1480, \"init\": 0, \"step\": 1, \"unit\": \"℉\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "135",
+      "dpValue": "AAAAAAAAAAAAAA==",
+      "dpProperty": "{}",
+      "dpMode": "rw",
+      "dpType": "raw"
+    },
+    {
+      "dpId": "145",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 100000, \"min\": 0, \"init\": 0, \"step\": 1, \"unit\": \"Hrs\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "146",
+      "dpValue": "AQE=",
+      "dpProperty": "{}",
+      "dpMode": "rw",
+      "dpType": "raw"
+    },
+    {
+      "dpId": "152",
+      "dpValue": true,
+      "dpProperty": "{\"true\": \"上报频率加速\", \"false\": \"不处理\"}",
+      "dpMode": "wo",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "153",
+      "dpValue": null,
+      "dpProperty": "{\"true\": \"开启\", \"false\": \"关闭\"}",
+      "dpMode": "rw",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "154",
+      "dpValue": false,
+      "dpProperty": "{\"true\": \"泳池盖盖上，app显示泳池盖 \", \"false\": \"泳池盖打开，app不显示泳池盖\"}",
+      "dpMode": "ro",
+      "dpType": "bool"
+    }
+  ]
+}

--- a/tests/fixtures/sand_cylinder.json
+++ b/tests/fixtures/sand_cylinder.json
@@ -1,0 +1,176 @@
+{
+  "id": "1000000000000000003",
+  "deviceName": "Test MPV",
+  "categoryCode": "sandCylinder",
+  "version": null,
+  "dps": [
+    {
+      "dpId": "101",
+      "dpValue": 141,
+      "dpProperty": "{\"max\": 1200, \"min\": -300, \"init\": \"0\", \"step\": \"1\", \"unit\": \"℃\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "102",
+      "dpValue": 17,
+      "dpProperty": "{\"max\": 600, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"Mpa\", \"scale\": 3}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "103",
+      "dpValue": 50,
+      "dpProperty": "{\"max\": 600, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"Mpa\", \"scale\": 3}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "104",
+      "dpValue": 250,
+      "dpProperty": "{\"max\": 600, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"Mpa\", \"scale\": 3}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "105",
+      "dpValue": 200,
+      "dpProperty": "{\"max\": 2500, \"min\": 0, \"init\": 50, \"step\": 1, \"unit\": \"Mpa\", \"scale\": 3}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "106",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"无动作\", \"1\": \"一键冲洗（反冲洗+正冲洗)\", \"2\": \"切换到循环位置\", \"3\": \"切换到关闭位置\", \"4\": \"切换到过滤位置\", \"5\": \"切换到排污位置\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "107",
+      "dpValue": 6,
+      "dpProperty": "{\"0\": \"Undetermined\", \"1\": \"Backwash\", \"2\": \"RECIRC\", \"3\": \"Washing\", \"4\": \"CLOSED\", \"5\": \"WASTE\", \"6\": \"FILTER\", \"7\": \"valve rotation\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "108",
+      "dpValue": 5,
+      "dpProperty": "{\"max\": 5, \"min\": 0, \"init\": 2, \"step\": 1, \"unit\": \"℃\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "109",
+      "dpValue": 7,
+      "dpProperty": "{\"max\": 30, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"day\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "110",
+      "dpValue": 1000,
+      "dpProperty": "{\"max\": 2359, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "111",
+      "dpValue": 3,
+      "dpProperty": "{\"max\": 25, \"min\": 1, \"init\": 1, \"step\": 1, \"unit\": \"min\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "112",
+      "dpValue": 30,
+      "dpProperty": "{\"max\": 50, \"min\": 10, \"init\": 10, \"step\": 1, \"unit\": \"%\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "113",
+      "dpValue": 100,
+      "dpProperty": "{\"max\": 100, \"min\": 60, \"init\": 60, \"step\": 5, \"unit\": \"%\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "114",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 2359, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "115",
+      "dpValue": 5,
+      "dpProperty": "{\"max\": 30, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"day\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "116",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 2550, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"s\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "118",
+      "dpValue": 3,
+      "dpProperty": "{\"0\": \"Mpa\", \"1\": \"Kpa\", \"2\": \"Psi\", \"3\": \"bar\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "119",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 2147483647, \"min\": -2147483647, \"init\": 0, \"step\": 1, \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "120",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"0-控制水泵\", \"1\": \"1-485-modbus\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "121",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"变频泵\", \"1\": \"定速泵\", \"2\": \"DI控制变速泵\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "122",
+      "dpValue": null,
+      "dpProperty": "{\"maxlen\": 2048}",
+      "dpMode": "rw",
+      "dpType": "string"
+    },
+    {
+      "dpId": "123",
+      "dpValue": 1,
+      "dpProperty": "{\"0\": \"禁止温度检测\", \"1\": \"检测摄氏温度\", \"2\": \"检测华氏温度\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "124",
+      "dpValue": 70449,
+      "dpProperty": "{\"max\": 2147483647, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "125",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"无\", \"1\": \"开启水泵\", \"2\": \"关闭水泵\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    }
+  ]
+}

--- a/tests/fixtures/water_pump.json
+++ b/tests/fixtures/water_pump.json
@@ -1,0 +1,134 @@
+{
+  "id": "1000000000000000002",
+  "deviceName": "Test Water Pump",
+  "categoryCode": "waterPump",
+  "version": null,
+  "dps": [
+    {
+      "dpId": "5",
+      "dpValue": 46,
+      "dpProperty": "{\"max\": 3000, \"min\": 0, \"init\": \"0\", \"step\": 1, \"unit\": \"W\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "101",
+      "dpValue": 25,
+      "dpProperty": "{\"max\": 1000, \"min\": 0, \"init\": \"0\", \"step\": 1, \"unit\": \"m³/h，l/min,lmp gpm,us gpm\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "102",
+      "dpValue": 30,
+      "dpProperty": "{\"max\": 120, \"min\": 0, \"init\": \"0\", \"step\": 5, \"unit\": \"%\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "103",
+      "dpValue": 1,
+      "dpProperty": "{\"0\": \"AI\", \"1\": \"MI\", \"2\": \"backwash\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "104",
+      "dpValue": 1500,
+      "dpProperty": "{\"max\": 1500, \"min\": 0, \"init\": \"0\", \"step\": 30, \"unit\": \"s\", \"scale\": 0}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "105",
+      "dpValue": true,
+      "dpProperty": "{\"true\": \"on\", \"false\": \"off\"}",
+      "dpMode": "rw",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "106",
+      "dpValue": 5,
+      "dpProperty": "{\"max\": 1000, \"min\": 0, \"init\": \"0\", \"step\": 1, \"unit\": \"m³/h，l/min,lmp gpm,us gpm\", \"scale\": 0}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "107",
+      "dpValue": 5,
+      "dpProperty": "{\"max\": 140, \"min\": 0, \"init\": \"0\", \"step\": 1, \"unit\": \"m³/h，l/min,lmp gpm,us gpm\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "108",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 1500, \"min\": 0, \"init\": \"0\", \"step\": 30, \"unit\": \"s\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "109",
+      "dpValue": 15,
+      "dpProperty": "{\"max\": 300, \"min\": 0, \"init\": \"0\", \"step\": 1, \"unit\": \"kw·h\", \"scale\": 2}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "110",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"m³/h\", \"1\": \"L/min\", \"2\": \"US gpm\", \"3\": \"IMP gpm\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "111",
+      "dpValue": 30,
+      "dpProperty": "{\"max\": 120, \"min\": 30, \"init\": 30, \"step\": 5, \"unit\": \"%\", \"scale\": 0}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "112",
+      "dpValue": 3,
+      "dpProperty": "{\"max\": 1000, \"min\": 0, \"init\": \"0\", \"step\": 1, \"unit\": \"m³/h, l/min, imp gpm, us gpm\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "113",
+      "dpValue": 1,
+      "dpProperty": "{\"max\": 20, \"min\": 0, \"init\": \"0\", \"step\": 1, \"unit\": \"step\", \"scale\": 0}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "114",
+      "dpValue": false,
+      "dpProperty": "{\"true\": \"异常\", \"false\": \"正常\"}",
+      "dpMode": "ro",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "115",
+      "dpValue": true,
+      "dpProperty": "{\"true\": \"on\", \"false\": \"off\"}",
+      "dpMode": "ro",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "116",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"re1_0\", \"1\": \"re1_1\", \"2\": \"re1_2\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "117",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"re2_0\", \"1\": \"re2_1\", \"2\": \"re2_2\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    }
+  ]
+}

--- a/tests/test_salt_machine.py
+++ b/tests/test_salt_machine.py
@@ -1,0 +1,187 @@
+"""saltMachine (inverter salt chlorinator) entity creation tests, issue #80.
+
+Fed by tests/fixtures/salt_machine.json — a sanitized capture of a real
+device's data points from a user-attached diagnostics report.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from conftest import load_fixture
+
+
+@pytest.fixture
+def salt_devices() -> list[dict]:
+    return load_fixture("salt_machine.json")
+
+
+def _by_dp(entities: list) -> dict:
+    return {e._dp_id: e for e in entities}
+
+
+# --------------------------------------------------------------------------
+# Sensors
+# --------------------------------------------------------------------------
+def test_sensor_dps_created(setup_entities, salt_devices):
+    entities, _ = setup_entities("sensor", salt_devices)
+    dps = _by_dp(entities)
+    expected = {
+        "101",
+        "112",
+        "111",
+        "102",
+        "133",
+        "105",
+        "113",
+        "124",
+        "106",
+        "130",
+        "145",
+        "119",
+        "127",
+        "128",
+    }
+    assert set(dps) == expected
+
+
+def test_sensor_ph_is_scaled(setup_entities, salt_devices):
+    # dp 112 reports 69 with scale=1 → 6.9
+    entities, _ = setup_entities("sensor", salt_devices)
+    assert _by_dp(entities)["112"]._attr_native_value == pytest.approx(6.9)
+
+
+def test_sensor_pool_temp_celsius_and_fahrenheit(setup_entities, salt_devices):
+    dps = _by_dp(setup_entities("sensor", salt_devices)[0])
+    # dp 102 = 150 (scale 1) → 15.0 °C ; dp 133 = 590 (scale 1) → 59.0 °F
+    assert dps["102"]._attr_native_value == pytest.approx(15.0)
+    assert dps["133"]._attr_native_value == pytest.approx(59.0)
+
+
+def test_sensor_enum_maps_to_label(setup_entities, salt_devices):
+    dps = _by_dp(setup_entities("sensor", salt_devices)[0])
+    # dp 119 reports 0 → "WAIT" from its dpProperty enum.
+    assert dps["119"]._attr_native_value == "WAIT"
+    assert dps["119"]._attr_options == ["WAIT", "GOOD", "GREAT"]
+    # dp 128 is a raw display string, shown verbatim.
+    assert dps["128"]._attr_native_value == "AAAA"
+
+
+# --------------------------------------------------------------------------
+# Switches
+# --------------------------------------------------------------------------
+def test_switches_created_and_backwash_gated(setup_entities, salt_devices):
+    entities, _ = setup_entities("switch", salt_devices)
+    # dp 153 (backwash) is null on this firmware → skipped by require_value.
+    assert set(_by_dp(entities)) == {"103", "107", "121", "123"}
+
+
+def test_power_switch_keeps_legacy_unique_id(setup_entities, salt_devices):
+    entities, _ = setup_entities("switch", salt_devices)
+    power = _by_dp(entities)["103"]
+    device_id = salt_devices[0]["id"]
+    assert power._attr_unique_id == f"fairland_{device_id}_switch"
+
+
+def test_switch_write_records_call(setup_entities, salt_devices):
+    entities, client = setup_entities("switch", salt_devices)
+    turbo = _by_dp(entities)["107"]
+    asyncio.run(turbo.async_turn_on())
+    assert client.calls == [(salt_devices[0]["id"], "107", True)]
+
+
+# --------------------------------------------------------------------------
+# Selects
+# --------------------------------------------------------------------------
+def test_selects_created(setup_entities, salt_devices):
+    entities, _ = setup_entities("select", salt_devices)
+    dps = _by_dp(entities)
+    assert set(dps) == {"132", "122"}
+    # dp 132 reports 0 → "inverter"; full option set parsed from dpProperty.
+    assert dps["132"]._attr_current_option == "inverter"
+    assert dps["132"]._attr_options == ["inverter", "auto_ph", "manual"]
+    # dp 122 reports 1 → the "4 hours" option.
+    assert dps["122"]._attr_current_option == "4_hours"
+
+
+def test_select_write_records_int(setup_entities, salt_devices):
+    entities, client = setup_entities("select", salt_devices)
+    asyncio.run(_by_dp(entities)["132"].async_select_option("manual"))
+    # "manual" maps to firmware int 3.
+    assert client.calls == [(salt_devices[0]["id"], "132", 3)]
+
+
+# --------------------------------------------------------------------------
+# Numbers
+# --------------------------------------------------------------------------
+def test_numbers_created(setup_entities, salt_devices):
+    entities, _ = setup_entities("number", salt_devices)
+    assert set(_by_dp(entities)) == {"110", "108", "125", "109", "126"}
+
+
+def test_ph_setpoint_scaled_range_and_value(setup_entities, salt_devices):
+    ph = _by_dp(setup_entities("number", salt_devices)[0])["110"]
+    # dpProperty min/max/step (65/85/1, scale 1) → 6.5/8.5/0.1 ; value 74 → 7.4
+    assert ph._attr_native_min_value == pytest.approx(6.5)
+    assert ph._attr_native_max_value == pytest.approx(8.5)
+    assert ph._attr_native_step == pytest.approx(0.1)
+    assert ph._attr_native_value == pytest.approx(7.4)
+
+
+def test_ph_setpoint_write_scales_back_to_raw(setup_entities, salt_devices):
+    entities, client = setup_entities("number", salt_devices)
+    asyncio.run(_by_dp(entities)["110"].async_set_native_value(7.6))
+    # Displayed pH 7.6 must reach the firmware as the raw integer 76.
+    assert client.calls == [(salt_devices[0]["id"], "110", 76)]
+
+
+def test_orp_setpoint_unscaled(setup_entities, salt_devices):
+    orp = _by_dp(setup_entities("number", salt_devices)[0])["108"]
+    assert orp._attr_native_min_value == pytest.approx(200)
+    assert orp._attr_native_max_value == pytest.approx(850)
+    assert orp._attr_native_value == pytest.approx(650)
+
+
+# --------------------------------------------------------------------------
+# Binary sensors
+# --------------------------------------------------------------------------
+def test_binary_sensors_gate_null_dps(setup_entities, salt_devices):
+    # On this firmware only the pool cover (154) is populated; the four
+    # alarm dps are null → require_value skips them.
+    entities, _ = setup_entities("binary_sensor", salt_devices)
+    assert set(_by_dp(entities)) == {"154"}
+    assert _by_dp(entities)["154"].is_on is False
+
+
+def _salt_with_dp(dp_id: str, value) -> list[dict]:
+    return [
+        {
+            "id": "1000000000000000009",
+            "deviceName": "Synthetic",
+            "categoryCode": "saltMachine",
+            "version": None,
+            "dps": [{"dpId": dp_id, "dpValue": value, "dpType": "bool"}],
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("flow_value", "expected_problem"),
+    # dp 114 true = 有水流 (flow present): the PROBLEM is the *absence* of flow,
+    # so the sensor is inverted.
+    [(True, False), (False, True)],
+)
+def test_water_flow_polarity_is_inverted(setup_entities, flow_value, expected_problem):
+    entities, _ = setup_entities("binary_sensor", _salt_with_dp("114", flow_value))
+    assert entities[0].is_on is expected_problem
+
+
+@pytest.mark.parametrize(
+    ("salt_value", "expected_problem"),
+    # dp 117 true = 加盐 (needs salt) — already the problem state, not inverted.
+    [(True, True), (False, False)],
+)
+def test_salt_low_polarity_not_inverted(setup_entities, salt_value, expected_problem):
+    entities, _ = setup_entities("binary_sensor", _salt_with_dp("117", salt_value))
+    assert entities[0].is_on is expected_problem

--- a/tests/test_salt_machine.py
+++ b/tests/test_salt_machine.py
@@ -185,3 +185,18 @@ def test_water_flow_polarity_is_inverted(setup_entities, flow_value, expected_pr
 def test_salt_low_polarity_not_inverted(setup_entities, salt_value, expected_problem):
     entities, _ = setup_entities("binary_sensor", _salt_with_dp("117", salt_value))
     assert entities[0].is_on is expected_problem
+
+
+@pytest.mark.parametrize(
+    ("calibration_value", "expected_problem"),
+    # dp 116 true = "Calibration required" — a status, not inverted.
+    [(True, True), (False, False)],
+)
+def test_calibration_required_polarity(
+    setup_entities, calibration_value, expected_problem
+):
+    entities, _ = setup_entities(
+        "binary_sensor", _salt_with_dp("116", calibration_value)
+    )
+    assert entities[0]._attr_name == "Calibration Required"
+    assert entities[0].is_on is expected_problem

--- a/tests/test_sand_cylinder.py
+++ b/tests/test_sand_cylinder.py
@@ -1,0 +1,123 @@
+"""sandCylinder (multiport valve / sand-filter controller) tests, #80/#81.
+
+Fed by tests/fixtures/sand_cylinder.json — a sanitized capture of a real
+MPV device's data points.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from conftest import load_fixture
+
+
+@pytest.fixture
+def mpv_devices() -> list[dict]:
+    return load_fixture("sand_cylinder.json")
+
+
+def _by_dp(entities: list) -> dict:
+    return {e._dp_id: e for e in entities}
+
+
+# --------------------------------------------------------------------------
+# Sensors
+# --------------------------------------------------------------------------
+def test_sensor_dps_created(setup_entities, mpv_devices):
+    entities, _ = setup_entities("sensor", mpv_devices)
+    assert set(_by_dp(entities)) == {"101", "102", "107", "115", "116"}
+
+
+def test_water_temperature_scaled(setup_entities, mpv_devices):
+    # dp 101 = 141 (scale 1) → 14.1 °C
+    dps = _by_dp(setup_entities("sensor", mpv_devices)[0])
+    assert dps["101"]._attr_native_value == pytest.approx(14.1)
+
+
+def test_pressure_scaled_to_mpa(setup_entities, mpv_devices):
+    # dp 102 = 17 (scale 3) → 0.017 MPa, reported with a plain MPa unit.
+    dps = _by_dp(setup_entities("sensor", mpv_devices)[0])
+    assert dps["102"]._attr_native_value == pytest.approx(0.017)
+    assert dps["102"]._attr_native_unit_of_measurement == "MPa"
+
+
+def test_valve_position_enum_label(setup_entities, mpv_devices):
+    # dp 107 = 6 → "FILTER" (English labels live in the dpProperty).
+    dps = _by_dp(setup_entities("sensor", mpv_devices)[0])
+    assert dps["107"]._attr_native_value == "FILTER"
+    assert {"Backwash", "FILTER", "CLOSED"} <= set(dps["107"]._attr_options)
+
+
+# --------------------------------------------------------------------------
+# Numbers
+# --------------------------------------------------------------------------
+def test_numbers_created(setup_entities, mpv_devices):
+    entities, _ = setup_entities("number", mpv_devices)
+    assert set(_by_dp(entities)) == {"105", "108", "109", "111", "112", "113"}
+
+
+def test_trigger_pressure_scaled(setup_entities, mpv_devices):
+    # dp 105 = 200 (scale 3) → 0.200 MPa; range 0 .. 2.5.
+    num = _by_dp(setup_entities("number", mpv_devices)[0])["105"]
+    assert num._attr_native_value == pytest.approx(0.200)
+    assert num._attr_native_min_value == pytest.approx(0)
+    assert num._attr_native_max_value == pytest.approx(2.5)
+
+
+def test_trigger_pressure_write_scales_back(setup_entities, mpv_devices):
+    entities, client = setup_entities("number", mpv_devices)
+    asyncio.run(_by_dp(entities)["105"].async_set_native_value(0.250))
+    # 0.250 MPa must reach the firmware as raw 250.
+    assert client.calls == [(mpv_devices[0]["id"], "105", 250)]
+
+
+# --------------------------------------------------------------------------
+# Selects
+# --------------------------------------------------------------------------
+def test_selects_created(setup_entities, mpv_devices):
+    entities, _ = setup_entities("select", mpv_devices)
+    assert set(_by_dp(entities)) == {"106", "125", "118", "123"}
+
+
+def test_mode_switch_options_by_int_key(setup_entities, mpv_devices):
+    # dp 106 labels are localized; options come from the int-key map.
+    mode = _by_dp(setup_entities("select", mpv_devices)[0])["106"]
+    assert mode._attr_options == [
+        "no_movement",
+        "one_touch_rinse",
+        "recirc",
+        "closed",
+        "filter",
+        "waste",
+    ]
+    # Device reports 0 → "no movement".
+    assert mode._attr_current_option == "no_movement"
+
+
+def test_mode_switch_write_sends_int(setup_entities, mpv_devices):
+    entities, client = setup_entities("select", mpv_devices)
+    asyncio.run(_by_dp(entities)["106"].async_select_option("filter"))
+    # "filter" maps to firmware int 4.
+    assert client.calls == [(mpv_devices[0]["id"], "106", 4)]
+
+
+def test_config_selects_marked_diagnostic_config(setup_entities, mpv_devices):
+    dps = _by_dp(setup_entities("select", mpv_devices)[0])
+    assert dps["118"]._attr_entity_category == "CONFIG"
+    assert dps["123"]._attr_entity_category == "CONFIG"
+    # The main mode control is a primary entity (no category).
+    assert dps["106"]._attr_entity_category is None
+
+
+# --------------------------------------------------------------------------
+# No binary sensors / switches for this category
+# --------------------------------------------------------------------------
+def test_no_binary_sensors(setup_entities, mpv_devices):
+    entities, _ = setup_entities("binary_sensor", mpv_devices)
+    assert entities == []
+
+
+def test_no_switches(setup_entities, mpv_devices):
+    entities, _ = setup_entities("switch", mpv_devices)
+    assert entities == []

--- a/tests/test_water_pump.py
+++ b/tests/test_water_pump.py
@@ -1,0 +1,54 @@
+"""Water-pump regression tests.
+
+The saltMachine work generalized the switch platform and refactored the
+sensor/number value paths. These guard that existing water-pump entities —
+especially the power switch's legacy unique_id — keep working.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import load_fixture
+
+
+@pytest.fixture
+def water_pump() -> list[dict]:
+    return load_fixture("water_pump.json")
+
+
+def _by_dp(entities: list) -> dict:
+    return {e._dp_id: e for e in entities}
+
+
+def test_power_switch_unique_id_unchanged(setup_entities, water_pump):
+    entities, _ = setup_entities("switch", water_pump)
+    # Exactly one switch (power, dp 105), and it must keep the bare `_switch`
+    # unique_id so existing installs don't lose entity history.
+    assert len(entities) == 1
+    assert entities[0]._dp_id == "105"
+    assert entities[0]._attr_unique_id == f"fairland_{water_pump[0]['id']}_switch"
+
+
+def test_mode_select_still_created(setup_entities, water_pump):
+    entities, _ = setup_entities("select", water_pump)
+    # The water pump keeps its dedicated mode-select class (dp 103).
+    assert len(entities) == 1
+    select = entities[0]
+    assert type(select).__name__ == "FairlandWaterPumpModeSelect"
+    assert select._attr_unique_id == f"fairland_{water_pump[0]['id']}_mode"
+    assert select._attr_current_option is not None
+
+
+def test_speed_setpoint_number_created(setup_entities, water_pump):
+    entities, _ = setup_entities("number", water_pump)
+    assert "111" in _by_dp(entities)
+
+
+def test_current_power_sensor_created(setup_entities, water_pump):
+    entities, _ = setup_entities("sensor", water_pump)
+    assert _by_dp(entities)["5"]._attr_native_value == 46
+
+
+def test_no_binary_sensors_for_water_pump(setup_entities, water_pump):
+    entities, _ = setup_entities("binary_sensor", water_pump)
+    assert entities == []


### PR DESCRIPTION
Adds support for two device categories that show up in the same iGarden account but weren't covered yet: inverter salt chlorinators (`saltMachine`, i-Salt and OEM rebrands) and the multiport valve / sand-filter controller (`sandCylinder`). Both built and verified against a real diagnostics report from #80.

### Salt chlorinator
- Sensors: salt ppm, pH, ORP, pool temperature (°C and °F), controller temperature, power, current, runtime, water quality, chlorine output
- Switches: power, turbo, timer, real-time salinity monitoring
- Selects: operating mode, polarity-reversal interval
- Numbers: pH, ORP, chlorine output, pool volume, acid dosing setpoints
- Binary sensors: water flow, acid dosing, salt-low, replace-probe, pool cover (new `binary_sensor` platform)

pH reads and writes in real units (firmware sends it ×10), and the alarm polarity comes straight from the firmware labels instead of a guess.

### Multiport valve
- Sensors: water temperature, pressure, current valve position, backwash countdowns
- Numbers: backwash-trigger pressure, low-temp protection, interval, duration, ratios
- Selects: mode switch, pump control, pressure unit, temperature detection

Entity and option names are taken verbatim from the firmware's own `nameLanguage` in the diagnostics. Its enum labels are localized, so these selects map by the integer key rather than by label.

Common care across both: data points the firmware leaves empty are skipped, and the existing power switch keeps its `unique_id` so heat-pump and water-pump installs are untouched.

### Tests
First test suite for this repo: stub-based pytest that runs without a Home Assistant install, fed by sanitized device fixtures, and wired into CI.

Refs #80. Closing once a salt-chlorinator user confirms on their own device.