### PR TITLE
feat: fill in pool-pump flow entities

### DIFF
--- a/custom_components/fairland/binary_sensor.py
+++ b/custom_components/fairland/binary_sensor.py
@@ -26,6 +26,7 @@ from .const import (
     DOMAIN,
     LOGGER,
     SALT_MACHINE_CATEGORY_CODE,
+    WATER_PUMP_CATEGORY_CODE,
 )
 from .entity import FairlandEntity
 
@@ -92,8 +93,21 @@ SALT_MACHINE_BINARY_SENSOR_TYPES: dict[str, dict[str, Any]] = {
     },
 }
 
+# Pool-pump binary sensors (issue #79/#80). dp 114 true = 异常 ("Abnormal"
+# per firmware nameLanguage) — already the problem state, not inverted. It is
+# populated on this firmware, so no require_value gate.
+WATER_PUMP_BINARY_SENSOR_TYPES: dict[str, dict[str, Any]] = {
+    "114": {
+        "name": "Pressure Alarm",
+        "icon": "mdi:gauge-low",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+}
+
 CATEGORY_BINARY_SENSOR_TYPES = {
     SALT_MACHINE_CATEGORY_CODE: SALT_MACHINE_BINARY_SENSOR_TYPES,
+    WATER_PUMP_CATEGORY_CODE: WATER_PUMP_BINARY_SENSOR_TYPES,
 }
 
 

--- a/custom_components/fairland/const.py
+++ b/custom_components/fairland/const.py
@@ -37,3 +37,9 @@ SALT_MACHINE_CATEGORY_CODE = "saltMachine"
 # Multiport valve / sand-filter controller (MPV, issue #80/#81). Again its
 # own dpId namespace.
 SAND_CYLINDER_CATEGORY_CODE = "sandCylinder"
+
+# Pool-pump flow values (dp 101/106/107/112) are reported in the unit the
+# user selects via dp 110, so flow entities derive their unit from it rather
+# than hardcoding one.
+WATER_PUMP_FLOW_UNIT_DP = "110"
+WATER_PUMP_FLOW_UNITS = {0: "m³/h", 1: "L/min", 2: "US gpm", 3: "IMP gpm"}

--- a/custom_components/fairland/number.py
+++ b/custom_components/fairland/number.py
@@ -26,6 +26,8 @@ from .const import (
     SALT_MACHINE_CATEGORY_CODE,
     SAND_CYLINDER_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
+    WATER_PUMP_FLOW_UNIT_DP,
+    WATER_PUMP_FLOW_UNITS,
 )
 from .entity import FairlandEntity
 
@@ -125,7 +127,31 @@ WATER_PUMP_NUMBER_TYPES = {
         "mode": NumberMode.BOX,
         "entity_category": EntityCategory.CONFIG,
     },
+    # Flow setpoint (used in flow-control mode). Its unit follows the dp 110
+    # selection, so it carries no static unit; min/max come from dpProperty.
+    "106": {
+        "name": "Flow Setpoint",
+        "unit": None,
+        "icon": "mdi:waves-arrow-up",
+        "min": 0,
+        "max": 1000,
+        "step": 1,
+        "mode": NumberMode.BOX,
+        "flow_unit": True,
+    },
 }
+
+
+def _resolve_flow_unit(dp_map: dict[str, Any]) -> str | None:
+    """Resolve a pool pump's flow unit from its dp 110 selection."""
+    dp = dp_map.get(WATER_PUMP_FLOW_UNIT_DP)
+    if dp is None:
+        return None
+    try:
+        return WATER_PUMP_FLOW_UNITS.get(int(dp.get("dpValue")))
+    except (TypeError, ValueError):
+        return None
+
 
 # Inverter salt chlorinator (saltMachine) writable setpoints (issue #80).
 # min/max/step are overridden from each device's dpProperty below, so the
@@ -368,6 +394,8 @@ class FairlandNumber(FairlandEntity, NumberEntity):
         # Firmware reports/accepts the raw integer value × 10^scale (e.g. pH
         # as 74 for 7.4); 0 means the value is already in display units.
         self._scale = config.get("scale", 0)
+        # Flow setpoint takes its unit from dp 110 (m³/h, L/min, ...).
+        self._flow_unit = config.get("flow_unit", False)
 
         # Set attributes based on config
         self._attr_name = config["name"]
@@ -401,6 +429,9 @@ class FairlandNumber(FairlandEntity, NumberEntity):
     def _update_value(self):
         """Update value from device data."""
         if "dps" in self._device_info:
+            if self._flow_unit:
+                dp_map = {dp["dpId"]: dp for dp in self._device_info["dps"]}
+                self._attr_native_unit_of_measurement = _resolve_flow_unit(dp_map)
             for dp in self._device_info["dps"]:
                 if dp["dpId"] == self._dp_id:
                     value = self._effective_dp_value(self._dp_id, dp["dpValue"])

--- a/custom_components/fairland/select.py
+++ b/custom_components/fairland/select.py
@@ -42,6 +42,16 @@ if TYPE_CHECKING:
 WATER_PUMP_MODE_DP_ID = "103"
 WATER_PUMP_MODE_TRANSLATION_KEY = "water_pump_mode"
 
+# Pool-pump flow-unit selector (dp 110). Drives the unit shown by the flow
+# sensors and the flow setpoint. Maps by integer key.
+WATER_PUMP_FLOW_UNIT_DP_ID = "110"
+WATER_PUMP_FLOW_UNIT_SELECT: dict[str, Any] = {
+    "translation_key": "water_pump_flow_unit",
+    "icon": "mdi:cup-water",
+    "entity_category": EntityCategory.CONFIG,
+    "int_to_option": {0: "m3h", 1: "l_min", 2: "us_gpm", 3: "imp_gpm"},
+}
+
 # Known firmware enum labels → translation-key option names. Option names
 # are lowercase snake_case to match the translation file convention.
 # Labels not listed here fall through to ``slugify(label)`` and are shown
@@ -201,13 +211,21 @@ async def async_setup_entry(
         category = device_info.get("categoryCode")
 
         if category == WATER_PUMP_CATEGORY_CODE:
-            if any(
-                dp.get("dpId") == WATER_PUMP_MODE_DP_ID for dp in device_info["dps"]
-            ):
+            dp_ids = {dp.get("dpId") for dp in device_info["dps"]}
+            if WATER_PUMP_MODE_DP_ID in dp_ids:
                 entities.append(
                     FairlandWaterPumpModeSelect(
                         coordinator=entry.runtime_data.coordinator,
                         device_info=device_info,
+                    )
+                )
+            if WATER_PUMP_FLOW_UNIT_DP_ID in dp_ids:
+                entities.append(
+                    FairlandDpSelect(
+                        coordinator=entry.runtime_data.coordinator,
+                        device_info=device_info,
+                        dp_id=WATER_PUMP_FLOW_UNIT_DP_ID,
+                        config=WATER_PUMP_FLOW_UNIT_SELECT,
                     )
                 )
         elif category in (SALT_MACHINE_CATEGORY_CODE, SAND_CYLINDER_CATEGORY_CODE):

--- a/custom_components/fairland/sensor.py
+++ b/custom_components/fairland/sensor.py
@@ -28,6 +28,8 @@ from .const import (
     SALT_MACHINE_CATEGORY_CODE,
     SAND_CYLINDER_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
+    WATER_PUMP_FLOW_UNIT_DP,
+    WATER_PUMP_FLOW_UNITS,
 )
 from .entity import FairlandEntity
 
@@ -287,6 +289,18 @@ DP_PROPERTY_TIME_UNITS = {
     "min": UnitOfTime.MINUTES,
 }
 
+
+def _resolve_flow_unit(dp_map: dict[str, Any]) -> str | None:
+    """Resolve a pool pump's flow unit from its dp 110 selection."""
+    dp = dp_map.get(WATER_PUMP_FLOW_UNIT_DP)
+    if dp is None:
+        return None
+    try:
+        return WATER_PUMP_FLOW_UNITS.get(int(dp.get("dpValue")))
+    except (TypeError, ValueError):
+        return None
+
+
 # Read-only data points exposed by Fairland-platform water pumps (e.g.
 # Inverflow Plus and OEM-rebadged variants such as Madimack). Energy is
 # reported as an integer with a dpProperty scale (typically scale=2), so it
@@ -325,6 +339,35 @@ WATER_PUMP_SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    # Flow values are expressed in the unit selected on dp 110, so they carry
+    # no static unit; `flow_unit` resolves it live (see _present_value path).
+    # The firmware's dpProperty unit field is a junk multi-unit string here.
+    "112": {
+        "name": "Water Flow",
+        "unit": None,
+        "icon": "mdi:waves-arrow-right",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "flow_unit": True,
+    },
+    "101": {
+        "name": "Maximum Flow Setting",
+        "unit": None,
+        "icon": "mdi:arrow-collapse-up",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "flow_unit": True,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "107": {
+        "name": "Minimum Flow Setting",
+        "unit": None,
+        "icon": "mdi:arrow-collapse-down",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "flow_unit": True,
+        "entity_category": EntityCategory.DIAGNOSTIC,
     },
 }
 
@@ -612,6 +655,8 @@ class FairlandSensor(FairlandEntity, SensorEntity):
         # Enum sensors map the raw integer value to a firmware label
         # ({"0": "WAIT", ...}); when set, scaling is skipped.
         self._enum_map = sensor_config.get("enum_map")
+        # Flow sensors take their unit from dp 110 (m³/h, L/min, ...).
+        self._flow_unit = sensor_config.get("flow_unit", False)
 
         # Set attributes based on sensor_config
         self._attr_name = sensor_config["name"]
@@ -668,6 +713,8 @@ class FairlandSensor(FairlandEntity, SensorEntity):
                 self._attr_native_value = self._present_value(
                     dp_map[self._dp_id]["dpValue"]
                 )
+                if self._flow_unit:
+                    self._attr_native_unit_of_measurement = _resolve_flow_unit(dp_map)
                 self._attr_available = True
                 return
 

--- a/custom_components/fairland/translations/en.json
+++ b/custom_components/fairland/translations/en.json
@@ -49,6 +49,15 @@
           "backwash": "Backwash"
         }
       },
+      "water_pump_flow_unit": {
+        "name": "Flow Unit",
+        "state": {
+          "m3h": "m³/h",
+          "l_min": "L/min",
+          "us_gpm": "US gpm",
+          "imp_gpm": "IMP gpm"
+        }
+      },
       "salt_machine_mode": {
         "name": "Mode",
         "state": {

--- a/tests/test_water_pump.py
+++ b/tests/test_water_pump.py
@@ -1,11 +1,13 @@
-"""Water-pump regression tests.
+"""Water-pump tests.
 
-The saltMachine work generalized the switch platform and refactored the
-sensor/number value paths. These guard that existing water-pump entities —
-especially the power switch's legacy unique_id — keep working.
+Cover both the pre-existing entities (regression: the power switch's legacy
+unique_id must not change) and the flow gap-filling entities added later
+(dp 101/106/107/110/112/114), fed by tests/fixtures/water_pump.json.
 """
 
 from __future__ import annotations
+
+import asyncio
 
 import pytest
 from conftest import load_fixture
@@ -20,6 +22,9 @@ def _by_dp(entities: list) -> dict:
     return {e._dp_id: e for e in entities}
 
 
+# --------------------------------------------------------------------------
+# Regression: pre-existing entities
+# --------------------------------------------------------------------------
 def test_power_switch_unique_id_unchanged(setup_entities, water_pump):
     entities, _ = setup_entities("switch", water_pump)
     # Exactly one switch (power, dp 105), and it must keep the bare `_switch`
@@ -31,12 +36,11 @@ def test_power_switch_unique_id_unchanged(setup_entities, water_pump):
 
 def test_mode_select_still_created(setup_entities, water_pump):
     entities, _ = setup_entities("select", water_pump)
-    # The water pump keeps its dedicated mode-select class (dp 103).
-    assert len(entities) == 1
-    select = entities[0]
-    assert type(select).__name__ == "FairlandWaterPumpModeSelect"
-    assert select._attr_unique_id == f"fairland_{water_pump[0]['id']}_mode"
-    assert select._attr_current_option is not None
+    mode = next(
+        e for e in entities if type(e).__name__ == "FairlandWaterPumpModeSelect"
+    )
+    assert mode._attr_unique_id == f"fairland_{water_pump[0]['id']}_mode"
+    assert mode._attr_current_option is not None
 
 
 def test_speed_setpoint_number_created(setup_entities, water_pump):
@@ -49,6 +53,58 @@ def test_current_power_sensor_created(setup_entities, water_pump):
     assert _by_dp(entities)["5"]._attr_native_value == 46
 
 
-def test_no_binary_sensors_for_water_pump(setup_entities, water_pump):
+# --------------------------------------------------------------------------
+# Flow gap-filling entities
+# --------------------------------------------------------------------------
+def test_flow_sensors_created(setup_entities, water_pump):
+    dps = _by_dp(setup_entities("sensor", water_pump)[0])
+    assert {"112", "101", "107"} <= set(dps)
+    assert dps["112"]._attr_native_value == 3
+
+
+def test_flow_sensor_unit_follows_dp110(setup_entities, water_pump):
+    # dp 110 = 0 → m³/h.
+    dps = _by_dp(setup_entities("sensor", water_pump)[0])
+    assert dps["112"]._attr_native_unit_of_measurement == "m³/h"
+
+
+def test_flow_sensor_unit_switches_with_dp110(setup_entities, water_pump):
+    # Flip dp 110 to 1 (L/min) and the flow unit must follow.
+    dev = water_pump[0]
+    for dp in dev["dps"]:
+        if dp["dpId"] == "110":
+            dp["dpValue"] = 1
+    dps = _by_dp(setup_entities("sensor", [dev])[0])
+    assert dps["112"]._attr_native_unit_of_measurement == "L/min"
+
+
+def test_flow_setpoint_number(setup_entities, water_pump):
+    num = _by_dp(setup_entities("number", water_pump)[0])["106"]
+    assert num._attr_native_value == 5
+    assert num._attr_native_unit_of_measurement == "m³/h"
+
+
+def test_flow_unit_select(setup_entities, water_pump):
+    sel = next(
+        e
+        for e in setup_entities("select", water_pump)[0]
+        if getattr(e, "_dp_id", None) == "110"
+    )
+    assert sel._attr_options == ["m3h", "l_min", "us_gpm", "imp_gpm"]
+    assert sel._attr_current_option == "m3h"
+    assert sel._attr_entity_category == "CONFIG"
+
+
+def test_flow_unit_select_write(setup_entities, water_pump):
+    entities, client = setup_entities("select", water_pump)
+    sel = next(e for e in entities if getattr(e, "_dp_id", None) == "110")
+    asyncio.run(sel.async_select_option("us_gpm"))
+    assert client.calls == [(water_pump[0]["id"], "110", 2)]
+
+
+def test_pressure_alarm_binary_sensor(setup_entities, water_pump):
+    # dp 114 = False → Normal → not a problem.
     entities, _ = setup_entities("binary_sensor", water_pump)
-    assert entities == []
+    alarm = _by_dp(entities)["114"]
+    assert alarm._attr_name == "Pressure Alarm"
+    assert alarm.is_on is False


### PR DESCRIPTION
Surfaces the water-pump data points the integration was leaving unused. They turned up while checking the #80 diagnostics for completeness, with names taken from the firmware's own `nameLanguage`.

New per pump:
- Sensors: real-time water flow, maximum and minimum flow setting
- Number: flow setpoint (used in flow-control mode)
- Select: flow unit (m³/h, L/min, US gpm, IMP gpm)
- Binary sensor: pressure alarm (Normal/Abnormal)

Flow values are reported in whatever unit the user selects on the flow-unit dp, so the flow sensors and the setpoint derive their unit from it live instead of hardcoding one. Reserved and internal-only data points are left out.

Stacked on #82 (it reuses the `binary_sensor` platform and the generic select introduced there); base will retarget to `main` once #82 merges. Refs #79.