### PR TITLE
feat: heat-pump remote-switch sensor + heat-pump tests

### DIFF
--- a/custom_components/fairland/sensor.py
+++ b/custom_components/fairland/sensor.py
@@ -278,6 +278,18 @@ HEAT_PUMP_SENSOR_TYPES = {
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
+    # Remote enable terminal (terminals 5/6). Read-only on/off status; the
+    # firmware enum maps 0=on / 1=off, so it is exposed as an enum sensor
+    # rather than a bool (a 0 value would otherwise coerce to "off").
+    "138": {
+        "name": "Remote Switch",
+        "unit": None,
+        "icon": "mdi:remote",
+        "device_class": SensorDeviceClass.ENUM,
+        "state_class": None,
+        "is_enum": True,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,13 @@ class _AttrStr:
         return name
 
 
+class _IntFlag:
+    """Bit-flag stand-in: attribute access returns an int so ``|`` works."""
+
+    def __getattr__(self, name: str) -> int:
+        return 1
+
+
 def _register(name: str, **attrs) -> types.ModuleType:
     module = types.ModuleType(name)
     for key, value in attrs.items():
@@ -91,6 +98,18 @@ def _install_stubs() -> None:
         CONF_PASSWORD="password",
         CONF_USERNAME="username",
         Platform=_AttrStr(),
+        ATTR_TEMPERATURE="temperature",
+        PRECISION_WHOLE=1,
+    )
+    _register(
+        "homeassistant.components.climate",
+        ClimateEntity=type("ClimateEntity", (), {}),
+    )
+    _register(
+        "homeassistant.components.climate.const",
+        ClimateEntityFeature=_IntFlag(),
+        HVACAction=_AttrStr(),
+        HVACMode=_AttrStr(),
     )
     _register("homeassistant.core", HomeAssistant=object)
     _register("homeassistant.util", slugify=_slugify)
@@ -163,7 +182,14 @@ def _load_integration() -> dict[str, types.ModuleType]:
         load(name)
     return {
         name: load(name)
-        for name in ("sensor", "switch", "select", "number", "binary_sensor")
+        for name in (
+            "sensor",
+            "switch",
+            "select",
+            "number",
+            "binary_sensor",
+            "climate",
+        )
     }
 
 

--- a/tests/fixtures/heat_pump.json
+++ b/tests/fixtures/heat_pump.json
@@ -1,0 +1,260 @@
+{
+  "id": "1000000000000000004",
+  "deviceName": "Test Heat Pump",
+  "categoryCode": "heatPump",
+  "version": null,
+  "dps": [
+    {
+      "dpId": "101",
+      "dpValue": true,
+      "dpProperty": "{\"true\": \"开\", \"false\": \"关\"}",
+      "dpMode": "rw",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "102",
+      "dpValue": 2,
+      "dpProperty": "{\"0\": \"Silence\", \"1\": \"Smart\", \"2\": \"Turbo\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "103",
+      "dpValue": 28,
+      "dpProperty": "{\"max\": 250, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "104",
+      "dpValue": false,
+      "dpProperty": "{\"true\": \"℉\", \"false\": \"℃\"}",
+      "dpMode": "rw",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "105",
+      "dpValue": 36,
+      "dpProperty": "{\"max\": 150, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"%\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "106",
+      "dpValue": 1,
+      "dpProperty": "{\"0\": \"Auto\", \"1\": \"Heating\", \"2\": \"Cooling\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "107",
+      "dpValue": 28,
+      "dpProperty": "{\"max\": 122, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "108",
+      "dpValue": 18,
+      "dpProperty": "{\"max\": 122, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "109",
+      "dpValue": 40,
+      "dpProperty": "{\"max\": 122, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "112",
+      "dpValue": 281,
+      "dpProperty": "{\"max\": 65535, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"kW\", \"scale\": 3}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "113",
+      "dpValue": true,
+      "dpProperty": "{\"true\": \"yes\", \"false\": \"no\"}",
+      "dpMode": "ro",
+      "dpType": "bool"
+    },
+    {
+      "dpId": "114",
+      "dpValue": 1,
+      "dpProperty": "{\"0\": \"no\", \"1\": \"yes\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "115",
+      "dpValue": 1,
+      "dpProperty": "{\"0\": \"no\", \"1\": \"yes\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "116",
+      "dpValue": 2,
+      "dpProperty": "{\"0\": \"continuous\", \"1\": \"water_temp_control\", \"2\": \"Time1water_temp_cont\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "117",
+      "dpValue": 60,
+      "dpProperty": "{\"max\": 120, \"min\": 10, \"init\": 10, \"step\": 5, \"unit\": \"min\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "118",
+      "dpValue": 30,
+      "dpProperty": "{\"max\": 90, \"min\": 30, \"init\": 30, \"step\": 1, \"unit\": \"min\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "119",
+      "dpValue": -7,
+      "dpProperty": "{\"max\": 250, \"min\": -30, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "120",
+      "dpValue": 12,
+      "dpProperty": "{\"max\": 12, \"min\": 1, \"init\": 1, \"step\": 1, \"unit\": \"min\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "121",
+      "dpValue": 13,
+      "dpProperty": "{\"max\": 100, \"min\": 8, \"init\": 8, \"step\": 1, \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "122",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"automatic\", \"1\": \"manual\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "123",
+      "dpValue": 3,
+      "dpProperty": "{\"max\": 100, \"min\": -10, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "124",
+      "dpValue": 2,
+      "dpProperty": "{\"max\": 100, \"min\": -10, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "125",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"automatic\", \"1\": \"manual\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "126",
+      "dpValue": 175,
+      "dpProperty": "{\"max\": 240, \"min\": 50, \"init\": 50, \"step\": 1, \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "127",
+      "dpValue": 175,
+      "dpProperty": "{\"max\": 240, \"min\": 50, \"init\": 50, \"step\": 1, \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "128",
+      "dpValue": 1,
+      "dpProperty": "{\"0\": \"no\", \"1\": \"yes\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "129",
+      "dpValue": 28,
+      "dpProperty": "{\"max\": 250, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "130",
+      "dpValue": 24,
+      "dpProperty": "{\"max\": 250, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "131",
+      "dpValue": 48,
+      "dpProperty": "{\"max\": 250, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "132",
+      "dpValue": 15,
+      "dpProperty": "{\"max\": 250, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "133",
+      "dpValue": 21,
+      "dpProperty": "{\"max\": 250, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "134",
+      "dpValue": 31,
+      "dpProperty": "{\"max\": 250, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "135",
+      "dpValue": 32,
+      "dpProperty": "{\"max\": 250, \"min\": -22, \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "136",
+      "dpValue": 93,
+      "dpProperty": "{\"max\": 600, \"min\": \"0\", \"init\": \"0\", \"step\": 2, \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "137",
+      "dpValue": 579,
+      "dpProperty": "{\"max\": 100000, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"r/min\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "138",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"on\", \"1\": \"off\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    }
+  ]
+}

--- a/tests/test_heat_pump.py
+++ b/tests/test_heat_pump.py
@@ -1,0 +1,79 @@
+"""Heat-pump tests, fed by tests/fixtures/heat_pump.json (a sanitized
+capture of the maintainer's own device — the integration's primary target,
+previously without any test coverage)."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import load_fixture
+
+
+@pytest.fixture
+def heat_pump() -> list[dict]:
+    return load_fixture("heat_pump.json")
+
+
+def _by_dp(entities: list) -> dict:
+    return {e._dp_id: e for e in entities}
+
+
+# --------------------------------------------------------------------------
+# Climate (the headline entity)
+# --------------------------------------------------------------------------
+def test_single_climate_entity(setup_entities, heat_pump):
+    entities, _ = setup_entities("climate", heat_pump)
+    assert len(entities) == 1
+
+
+def test_climate_reads_temperatures_and_mode(setup_entities, heat_pump):
+    climate = setup_entities("climate", heat_pump)[0][0]
+    # dp 103 inlet temp = 28, dp 107 setting temp = 28, dp 106 = 1 (Heating),
+    # power (dp 101) on, dp 102 = 2 (Turbo preset).
+    assert climate._attr_current_temperature == 28
+    assert climate._attr_target_temperature == 28
+    assert climate._attr_hvac_mode == "HEAT"
+    assert climate._attr_preset_mode == "Turbo"
+
+
+# --------------------------------------------------------------------------
+# Switch / sensors / numbers
+# --------------------------------------------------------------------------
+def test_power_switch(setup_entities, heat_pump):
+    entities, _ = setup_entities("switch", heat_pump)
+    assert len(entities) == 1
+    assert entities[0]._dp_id == "101"
+    assert entities[0]._attr_unique_id == f"fairland_{heat_pump[0]['id']}_switch"
+    assert entities[0].is_on is True
+
+
+def test_temperature_sensors(setup_entities, heat_pump):
+    dps = _by_dp(setup_entities("sensor", heat_pump)[0])
+    # dp 129 outlet water temp = 28, dp 130 ambient = 24.
+    assert dps["129"]._attr_native_value == 28
+    assert dps["130"]._attr_native_value == 24
+
+
+def test_power_sensor_scaled_to_kw(setup_entities, heat_pump):
+    # dp 112 = 281 with scale 3 → 0.281 kW.
+    dps = _by_dp(setup_entities("sensor", heat_pump)[0])
+    assert dps["112"]._attr_native_value == pytest.approx(0.281)
+
+
+def test_remote_switch_enum_sensor(setup_entities, heat_pump):
+    # dp 138 enum 0=on / 1=off; value 0 → "on" (must NOT coerce to a bool).
+    dps = _by_dp(setup_entities("sensor", heat_pump)[0])
+    assert dps["138"]._attr_native_value == "on"
+    assert dps["138"]._attr_options == ["on", "off"]
+
+
+def test_writable_numbers_created(setup_entities, heat_pump):
+    entities, _ = setup_entities("number", heat_pump)
+    assert set(_by_dp(entities)) == {"116", "117", "118", "119", "120", "121"}
+
+
+# --------------------------------------------------------------------------
+# Categories that should produce nothing for a heat pump
+# --------------------------------------------------------------------------
+def test_no_selects_or_binary_sensors(setup_entities, heat_pump):
+    assert setup_entities("select", heat_pump)[0] == []
+    assert setup_entities("binary_sensor", heat_pump)[0] == []


### PR DESCRIPTION
A completeness pass over the maintainer's own heat-pump diagnostics: 34 of 36 data points were already surfaced. The one real gap was dp 138, the remote-enable terminal (5/6) status, now added as an enum sensor. Its firmware enum is 0=on / 1=off, so a plain bool would misread a 0 as "off" — hence an enum sensor. The only other uncovered point, dp 104, is the cosmetic °C/°F display toggle and stays out.

This also adds the first test coverage for the heat pump, which is the integration's primary device and had none: a sanitized fixture plus tests across the climate, sensor, switch and number platforms. The test harness now stubs and loads the climate platform as well.

Refs #79.