### PR TITLE
feat: add swim-jet (poolSurfer) support (#85)

### DIFF
--- a/custom_components/fairland/binary_sensor.py
+++ b/custom_components/fairland/binary_sensor.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from .const import (
     DOMAIN,
     LOGGER,
+    POOL_SURFER_CATEGORY_CODE,
     SALT_MACHINE_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
 )
@@ -105,9 +106,22 @@ WATER_PUMP_BINARY_SENSOR_TYPES: dict[str, dict[str, Any]] = {
     },
 }
 
+# Counter-current swim jet (poolSurfer, issue #85). dp 4 = "The driver board
+# is faulty" (firmware nameLanguage); non-zero is the fault state, so it is a
+# PROBLEM sensor and is not inverted.
+POOL_SURFER_BINARY_SENSOR_TYPES: dict[str, dict[str, Any]] = {
+    "4": {
+        "name": "Driver Board Fault",
+        "icon": "mdi:alert-circle",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+}
+
 CATEGORY_BINARY_SENSOR_TYPES = {
     SALT_MACHINE_CATEGORY_CODE: SALT_MACHINE_BINARY_SENSOR_TYPES,
     WATER_PUMP_CATEGORY_CODE: WATER_PUMP_BINARY_SENSOR_TYPES,
+    POOL_SURFER_CATEGORY_CODE: POOL_SURFER_BINARY_SENSOR_TYPES,
 }
 
 

--- a/custom_components/fairland/const.py
+++ b/custom_components/fairland/const.py
@@ -37,6 +37,9 @@ SALT_MACHINE_CATEGORY_CODE = "saltMachine"
 # Multiport valve / sand-filter controller (MPV, issue #80/#81). Again its
 # own dpId namespace.
 SAND_CYLINDER_CATEGORY_CODE = "sandCylinder"
+# Counter-current swim jet (Fairland/iGarden "Swim Jet", productCode
+# iupstream1, issue #85). Yet another wholly separate dpId namespace.
+POOL_SURFER_CATEGORY_CODE = "poolSurfer"
 
 # Pool-pump flow values (dp 101/106/107/112) are reported in the unit the
 # user selects via dp 110, so flow entities derive their unit from it rather

--- a/custom_components/fairland/number.py
+++ b/custom_components/fairland/number.py
@@ -23,6 +23,7 @@ from .const import (
     DOMAIN,
     HEAT_PUMP_CATEGORY_CODE,
     LOGGER,
+    POOL_SURFER_CATEGORY_CODE,
     SALT_MACHINE_CATEGORY_CODE,
     SAND_CYLINDER_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
@@ -277,6 +278,55 @@ SAND_CYLINDER_NUMBER_TYPES = {
 }
 
 
+# Counter-current swim jet (poolSurfer, issue #85) writable setpoints. Names
+# from the firmware nameLanguage (en-US). dp 23 is the index data point
+# ("Current rotational speed", de "Aktuelle Geschwindigkeit") — the jet's
+# main speed control. dp 28/29/30 are the per-mode defaults. min/max/step
+# come from each dp's dpProperty. The device-clock register (dp 24) and the
+# raw training-program blobs (dp 31-38) are not exposed here.
+POOL_SURFER_NUMBER_TYPES = {
+    "23": {
+        "name": "Speed",
+        "unit": PERCENTAGE,
+        "icon": "mdi:speedometer",
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "mode": NumberMode.SLIDER,
+    },
+    "28": {
+        "name": "Free Mode Default Speed",
+        "unit": PERCENTAGE,
+        "icon": "mdi:speedometer-medium",
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "29": {
+        "name": "Timer Mode Default Speed",
+        "unit": PERCENTAGE,
+        "icon": "mdi:speedometer-medium",
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "30": {
+        "name": "Timer Mode Default Duration",
+        "unit": UnitOfTime.SECONDS,
+        "icon": "mdi:timer-cog",
+        "min": 0,
+        "max": 5999,
+        "step": 1,
+        "mode": NumberMode.BOX,
+        "entity_category": EntityCategory.CONFIG,
+    },
+}
+
+
 # Firmware-reported time units (dpProperty "unit") we trust to override a
 # default time unit: the backwash duration comes in seconds on some pumps
 # (e.g. InverFlow(L), issue #77) and minutes on others.
@@ -307,6 +357,8 @@ async def async_setup_entry(
             number_types = SALT_MACHINE_NUMBER_TYPES
         elif category == SAND_CYLINDER_CATEGORY_CODE:
             number_types = SAND_CYLINDER_NUMBER_TYPES
+        elif category == POOL_SURFER_CATEGORY_CODE:
+            number_types = POOL_SURFER_NUMBER_TYPES
         else:
             continue
 

--- a/custom_components/fairland/select.py
+++ b/custom_components/fairland/select.py
@@ -25,6 +25,7 @@ from .api import FairlandApiClientCommunicationError, FairlandApiClientError
 from .const import (
     DOMAIN,
     LOGGER,
+    POOL_SURFER_CATEGORY_CODE,
     SALT_MACHINE_CATEGORY_CODE,
     SAND_CYLINDER_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
@@ -133,6 +134,31 @@ SAND_CYLINDER_SELECT_TYPES: dict[str, dict[str, Any]] = {
 }
 
 
+# Counter-current swim jet (poolSurfer, issue #85). dp 21 = "Working mode"
+# (firmware nameLanguage): free/timer mode, four preset training programs, a
+# surf mode and a custom program. The dp's raw dpProperty labels are stale
+# ("TRAINING_MODE_P1..P6") and disagree with the firmware's own
+# dpPropertyNameLanguage, so options map by the integer key rather than the
+# label (the same approach the sandCylinder selects use).
+#
+# NOTE: selecting a training/surf program starts the jet running it.
+POOL_SURFER_SELECT_TYPES: dict[str, dict[str, Any]] = {
+    "21": {
+        "translation_key": "pool_surfer_mode",
+        "icon": "mdi:swim",
+        "int_to_option": {
+            0: "free_or_timed",
+            1: "training_1",
+            2: "training_2",
+            3: "training_3",
+            4: "training_4",
+            5: "surf",
+            6: "custom",
+        },
+    },
+}
+
+
 def _enum_int_keys(dp: dict[str, Any]) -> set[int]:
     """Return the set of integer enum keys advertised in a dp's dpProperty."""
     try:
@@ -228,12 +254,16 @@ async def async_setup_entry(
                         config=WATER_PUMP_FLOW_UNIT_SELECT,
                     )
                 )
-        elif category in (SALT_MACHINE_CATEGORY_CODE, SAND_CYLINDER_CATEGORY_CODE):
-            select_types = (
-                SALT_MACHINE_SELECT_TYPES
-                if category == SALT_MACHINE_CATEGORY_CODE
-                else SAND_CYLINDER_SELECT_TYPES
-            )
+        elif category in (
+            SALT_MACHINE_CATEGORY_CODE,
+            SAND_CYLINDER_CATEGORY_CODE,
+            POOL_SURFER_CATEGORY_CODE,
+        ):
+            select_types = {
+                SALT_MACHINE_CATEGORY_CODE: SALT_MACHINE_SELECT_TYPES,
+                SAND_CYLINDER_CATEGORY_CODE: SAND_CYLINDER_SELECT_TYPES,
+                POOL_SURFER_CATEGORY_CODE: POOL_SURFER_SELECT_TYPES,
+            }[category]
             dp_ids = {dp.get("dpId") for dp in device_info["dps"]}
             for dp_id, config in select_types.items():
                 if dp_id not in dp_ids:

--- a/custom_components/fairland/sensor.py
+++ b/custom_components/fairland/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfLength,
     UnitOfPower,
     UnitOfTemperature,
     UnitOfTime,
@@ -25,6 +26,7 @@ from .const import (
     DOMAIN,
     HEAT_PUMP_CATEGORY_CODE,
     LOGGER,
+    POOL_SURFER_CATEGORY_CODE,
     SALT_MACHINE_CATEGORY_CODE,
     SAND_CYLINDER_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
@@ -550,6 +552,148 @@ SAND_CYLINDER_SENSOR_TYPES = {
 }
 
 
+# Counter-current swim jet (poolSurfer, issue #85). Names are taken from the
+# firmware's own nameLanguage (en-US) like the sandCylinder map. dp 23 (the
+# speed control) and the operating-mode select live on the number/select
+# platforms. Pure firmware-debug dps (RTOS stack sizes, RCC flags, OTA size,
+# commissioning timers, device log, wifi level) are deliberately omitted.
+# Scale comes from each dp's dpProperty via the scale-from-property path.
+POOL_SURFER_SENSOR_TYPES = {
+    # dp 22 is the running-state machine, exposed read-only as an enum sensor
+    # (its dpProperty carries the value→label map: POWER_OFF, FREE_MODE_*, …).
+    "22": {
+        "name": "Status",
+        "unit": None,
+        "icon": "mdi:state-machine",
+        "device_class": SensorDeviceClass.ENUM,
+        "state_class": None,
+        "is_enum": True,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "2": {
+        "name": "Model",
+        "unit": None,
+        "icon": "mdi:identifier",
+        "device_class": SensorDeviceClass.ENUM,
+        "state_class": None,
+        "is_enum": True,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    # Session statistics (firmware "Complete(ion) Statistics_*"). All read 0
+    # while the jet is idle.
+    "42": {
+        "name": "Session Distance",
+        "unit": UnitOfLength.METERS,
+        "icon": "mdi:swim",
+        "device_class": SensorDeviceClass.DISTANCE,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "40": {
+        "name": "Session Duration",
+        "unit": UnitOfTime.SECONDS,
+        "icon": "mdi:timer-outline",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "41": {
+        "name": "Session Swimming Intensity",
+        "unit": PERCENTAGE,
+        "icon": "mdi:speedometer",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    # Electrical telemetry (all diagnostic).
+    "12": {
+        "name": "Motor Power",
+        "unit": UnitOfPower.WATT,
+        "icon": "mdi:flash",
+        "device_class": SensorDeviceClass.POWER,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "9": {
+        "name": "Motor Speed",
+        "unit": "rpm",
+        "icon": "mdi:fan",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "11": {
+        "name": "Commanded Speed",
+        "unit": "rpm",
+        "icon": "mdi:fan-chevron-up",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "10": {
+        "name": "Bus Voltage",
+        "unit": UnitOfElectricPotential.VOLT,
+        "icon": "mdi:sine-wave",
+        "device_class": SensorDeviceClass.VOLTAGE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "13": {
+        "name": "Bus Current",
+        "unit": UnitOfElectricCurrent.AMPERE,
+        "icon": "mdi:current-ac",
+        "device_class": SensorDeviceClass.CURRENT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "8": {
+        "name": "Motor Current",
+        "unit": UnitOfElectricCurrent.AMPERE,
+        "icon": "mdi:current-dc",
+        "device_class": SensorDeviceClass.CURRENT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    # Internal temperatures (all diagnostic).
+    "6": {
+        "name": "MOS Temperature",
+        "unit": UnitOfTemperature.CELSIUS,
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "7": {
+        "name": "Electrical Box Temperature",
+        "unit": UnitOfTemperature.CELSIUS,
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "50": {
+        "name": "Driver Board NTC Temperature 1",
+        "unit": UnitOfTemperature.CELSIUS,
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "51": {
+        "name": "Driver Board NTC Temperature 2",
+        "unit": UnitOfTemperature.CELSIUS,
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "52": {
+        "name": "Driver Board NTC Temperature 3",
+        "unit": UnitOfTemperature.CELSIUS,
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+}
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: FairlandConfigEntry,
@@ -574,6 +718,8 @@ async def async_setup_entry(
             sensor_types = SALT_MACHINE_SENSOR_TYPES
         elif category == SAND_CYLINDER_CATEGORY_CODE:
             sensor_types = SAND_CYLINDER_SENSOR_TYPES
+        elif category == POOL_SURFER_CATEGORY_CODE:
+            sensor_types = POOL_SURFER_SENSOR_TYPES
         else:
             continue
 

--- a/custom_components/fairland/translations/en.json
+++ b/custom_components/fairland/translations/en.json
@@ -109,6 +109,18 @@
           "celsius": "Celsius",
           "fahrenheit": "Fahrenheit"
         }
+      },
+      "pool_surfer_mode": {
+        "name": "Working Mode",
+        "state": {
+          "free_or_timed": "Free or timed mode",
+          "training_1": "Training Mode 1",
+          "training_2": "Training Mode 2",
+          "training_3": "Training Mode 3",
+          "training_4": "Training Mode 4",
+          "surf": "Surf mode",
+          "custom": "Custom"
+        }
       }
     }
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,7 @@ def _install_stubs() -> None:
         UnitOfElectricCurrent=_AttrStr(),
         UnitOfElectricPotential=_AttrStr(),
         UnitOfEnergy=_AttrStr(),
+        UnitOfLength=_AttrStr(),
         UnitOfPower=_AttrStr(),
         UnitOfTemperature=_AttrStr(),
         UnitOfTime=_AttrStr(),

--- a/tests/fixtures/pool_surfer.json
+++ b/tests/fixtures/pool_surfer.json
@@ -1,0 +1,162 @@
+{
+  "id": "1000000000000000085",
+  "deviceName": "Test Swim Jet",
+  "categoryCode": "poolSurfer",
+  "version": null,
+  "dps": [
+    {
+      "dpId": "2",
+      "dpValue": 1,
+      "dpProperty": "{\"0\": \"SJ230 (1900r)\", \"1\": \"SJ200 (1700r)\", \"2\": \"SJ160 (1470r)\", \"3\": \"SJ100 (1180r)\"}",
+      "dpMode": "ro",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "4",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 65535, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "6",
+      "dpValue": 347,
+      "dpProperty": "{\"max\": 1000, \"min\": -1000, \"init\": 25, \"step\": \"1\", \"unit\": \"°C\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "7",
+      "dpValue": 400,
+      "dpProperty": "{\"max\": 1000, \"min\": -1000, \"init\": 25, \"step\": \"1\", \"unit\": \"°C\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "8",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 10000, \"min\": -10000, \"init\": \"0\", \"step\": \"1\", \"unit\": \"A\", \"scale\": 2}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "9",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 65535, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"rpm\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "10",
+      "dpValue": 243,
+      "dpProperty": "{\"max\": 65535, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"V\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "11",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 65535, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"rpm\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "12",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 65535, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"w\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "13",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 65535, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"A\", \"scale\": 2}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "21",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"自由或定时模式\", \"1\": \"TRAINING_MODE_P1\", \"2\": \"TRAINING_MODE_P2\", \"3\": \"TRAINING_MODE_P3\", \"4\": \"TRAINING_MODE_P4\", \"5\": \"TRAINING_MODE_P5\", \"6\": \"TRAINING_MODE_P6\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "22",
+      "dpValue": 0,
+      "dpProperty": "{\"0\": \"POWER_OFF_STATUS\", \"1\": \"FREE_MODE_INITIAL\", \"2\": \"FREE_MODE_STARTING\", \"3\": \"FREE_MODE_RUNNING\", \"4\": \"FREE_MODE_SUSPEND\", \"5\": \"FREE_MODE_STOP\", \"6\": \"TIMING_MODE_INITIAL\", \"7\": \"TIMING_MODE_STARTING\", \"8\": \"TIMING_MODE_RUNNING\", \"9\": \"TIMING_MODE_SUSPEND\", \"10\": \"TIMING_MODE_STOP\", \"11\": \"TRAINING_MODE_INITIA\", \"12\": \"TRAINING_MODE_STARTI\", \"13\": \"TRAINING_MODE_RUNNIN\", \"14\": \"TRAINING_MODE_SUSPEN\", \"15\": \"TRAINING_MODE_STOP\"}",
+      "dpMode": "rw",
+      "dpType": "enum"
+    },
+    {
+      "dpId": "23",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 100, \"min\": \"0\", \"init\": 20, \"step\": \"1\", \"unit\": \"%\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "28",
+      "dpValue": 20,
+      "dpProperty": "{\"max\": 100, \"min\": \"0\", \"init\": 40, \"step\": \"1\", \"unit\": \"%\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "29",
+      "dpValue": 40,
+      "dpProperty": "{\"max\": 100, \"min\": \"0\", \"init\": 40, \"step\": \"1\", \"unit\": \"%\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "30",
+      "dpValue": 1800,
+      "dpProperty": "{\"max\": 5999, \"min\": \"0\", \"init\": 1800, \"step\": \"1\", \"unit\": \"秒\", \"scale\": \"0\"}",
+      "dpMode": "rw",
+      "dpType": "value"
+    },
+    {
+      "dpId": "40",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 65535, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \" (秒)\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "41",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 100, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"(%)\", \"scale\": \"0\"}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "42",
+      "dpValue": 0,
+      "dpProperty": "{\"max\": 2147483647, \"min\": \"0\", \"init\": \"0\", \"step\": \"1\", \"unit\": \"(米)\", \"scale\": 2}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "50",
+      "dpValue": 345,
+      "dpProperty": "{\"max\": 1000, \"min\": -1000, \"init\": \"0\", \"step\": \"1\", \"unit\": \"°C\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "51",
+      "dpValue": 347,
+      "dpProperty": "{\"max\": 1000, \"min\": -1000, \"init\": \"0\", \"step\": \"1\", \"unit\": \"°C\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    },
+    {
+      "dpId": "52",
+      "dpValue": 346,
+      "dpProperty": "{\"max\": 1000, \"min\": -1000, \"init\": \"0\", \"step\": \"1\", \"unit\": \"°C\", \"scale\": 1}",
+      "dpMode": "ro",
+      "dpType": "value"
+    }
+  ]
+}

--- a/tests/test_pool_surfer.py
+++ b/tests/test_pool_surfer.py
@@ -1,0 +1,168 @@
+"""poolSurfer (counter-current swim jet) tests, issue #85.
+
+Fed by tests/fixtures/pool_surfer.json — a sanitized capture of a real
+Swim Jet (productCode iupstream1). The device was idle at capture time, so
+most live values are 0; voltage (dp 10), the model/status enums and the
+operating-mode select carry real non-zero state, which is what the scaling
+and enum assertions below lean on. Entity names come from the firmware's own
+nameLanguage (en-US), as with the sandCylinder category.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from conftest import load_fixture
+
+
+@pytest.fixture
+def swim_jet_devices() -> list[dict]:
+    return load_fixture("pool_surfer.json")
+
+
+def _by_dp(entities: list) -> dict:
+    return {e._dp_id: e for e in entities}
+
+
+# --------------------------------------------------------------------------
+# Sensors
+# --------------------------------------------------------------------------
+def test_sensor_dps_created(setup_entities, swim_jet_devices):
+    entities, _ = setup_entities("sensor", swim_jet_devices)
+    assert set(_by_dp(entities)) == {
+        "2",
+        "22",
+        "42",
+        "40",
+        "41",
+        "12",
+        "9",
+        "11",
+        "10",
+        "13",
+        "8",
+        "6",
+        "7",
+        "50",
+        "51",
+        "52",
+    }
+
+
+def test_voltage_scaled(setup_entities, swim_jet_devices):
+    # dp 10 = 243 (scale 1) → 24.3 V.
+    dps = _by_dp(setup_entities("sensor", swim_jet_devices)[0])
+    assert dps["10"]._attr_native_value == pytest.approx(24.3)
+    assert dps["10"]._attr_native_unit_of_measurement == "VOLT"
+
+
+def test_internal_temperatures_scaled(setup_entities, swim_jet_devices):
+    # dp 6/50 are scale 1: 347 → 34.7 °C, 345 → 34.5 °C.
+    dps = _by_dp(setup_entities("sensor", swim_jet_devices)[0])
+    assert dps["6"]._attr_native_value == pytest.approx(34.7)
+    assert dps["50"]._attr_native_value == pytest.approx(34.5)
+    assert dps["6"]._attr_entity_category == "DIAGNOSTIC"
+
+
+def test_distance_unit_and_scale(setup_entities, swim_jet_devices):
+    # dp 42 carries the firmware unit "(米)" (meters) with scale 2; the unit
+    # comes from our config (METERS), not the Chinese firmware string.
+    dps = _by_dp(setup_entities("sensor", swim_jet_devices)[0])
+    assert dps["42"]._attr_native_unit_of_measurement == "METERS"
+    assert dps["42"]._attr_native_value == pytest.approx(0.0)
+
+
+def test_model_enum_label(setup_entities, swim_jet_devices):
+    # dp 2 = 1 → "SJ200 (1700r)" from the dpProperty enum labels.
+    dps = _by_dp(setup_entities("sensor", swim_jet_devices)[0])
+    assert dps["2"]._attr_native_value == "SJ200 (1700r)"
+
+
+def test_status_enum_label(setup_entities, swim_jet_devices):
+    # dp 22 = 0 → "POWER_OFF_STATUS" (idle). The enum sensor shows the raw
+    # dpProperty labels (the firmware's localized names live separately).
+    dps = _by_dp(setup_entities("sensor", swim_jet_devices)[0])
+    assert dps["22"]._attr_native_value == "POWER_OFF_STATUS"
+
+
+# --------------------------------------------------------------------------
+# Numbers (speed control + per-mode defaults)
+# --------------------------------------------------------------------------
+def test_numbers_created(setup_entities, swim_jet_devices):
+    entities, _ = setup_entities("number", swim_jet_devices)
+    assert set(_by_dp(entities)) == {"23", "28", "29", "30"}
+
+
+def test_speed_range_from_property(setup_entities, swim_jet_devices):
+    # dp 23 = 0 %, range 0 .. 100 from its dpProperty.
+    num = _by_dp(setup_entities("number", swim_jet_devices)[0])["23"]
+    assert num._attr_native_value == pytest.approx(0)
+    assert num._attr_native_min_value == pytest.approx(0)
+    assert num._attr_native_max_value == pytest.approx(100)
+    assert num._attr_native_unit_of_measurement == "%"
+
+
+def test_defaults_marked_config(setup_entities, swim_jet_devices):
+    dps = _by_dp(setup_entities("number", swim_jet_devices)[0])
+    assert dps["28"]._attr_entity_category == "CONFIG"
+    assert dps["30"]._attr_entity_category == "CONFIG"
+    # The live speed control is a primary entity (no category).
+    assert dps["23"]._attr_entity_category is None
+
+
+def test_speed_write_sends_int(setup_entities, swim_jet_devices):
+    entities, client = setup_entities("number", swim_jet_devices)
+    asyncio.run(_by_dp(entities)["23"].async_set_native_value(40))
+    assert client.calls == [(swim_jet_devices[0]["id"], "23", 40)]
+
+
+# --------------------------------------------------------------------------
+# Select (working mode)
+# --------------------------------------------------------------------------
+def test_selects_created(setup_entities, swim_jet_devices):
+    entities, _ = setup_entities("select", swim_jet_devices)
+    assert set(_by_dp(entities)) == {"21"}
+
+
+def test_mode_options_by_int_key(setup_entities, swim_jet_devices):
+    # dp 21's raw dpProperty labels (TRAINING_MODE_P*) are stale, so options
+    # come from the int-key map (correct labels live in the translations).
+    mode = _by_dp(setup_entities("select", swim_jet_devices)[0])["21"]
+    assert mode._attr_options == [
+        "free_or_timed",
+        "training_1",
+        "training_2",
+        "training_3",
+        "training_4",
+        "surf",
+        "custom",
+    ]
+    # Device reports 0 → free/timed mode.
+    assert mode._attr_current_option == "free_or_timed"
+
+
+def test_mode_write_sends_int(setup_entities, swim_jet_devices):
+    entities, client = setup_entities("select", swim_jet_devices)
+    asyncio.run(_by_dp(entities)["21"].async_select_option("surf"))
+    # "surf" maps to firmware int 5.
+    assert client.calls == [(swim_jet_devices[0]["id"], "21", 5)]
+
+
+# --------------------------------------------------------------------------
+# Binary sensor (driver board fault)
+# --------------------------------------------------------------------------
+def test_driver_board_fault_created(setup_entities, swim_jet_devices):
+    entities, _ = setup_entities("binary_sensor", swim_jet_devices)
+    bs = _by_dp(entities)
+    assert set(bs) == {"4"}
+    # dp 4 = 0 → no fault, and it is not inverted.
+    assert bs["4"].is_on is False
+
+
+# --------------------------------------------------------------------------
+# No switches / climate for this category
+# --------------------------------------------------------------------------
+def test_no_switches(setup_entities, swim_jet_devices):
+    entities, _ = setup_entities("switch", swim_jet_devices)
+    assert entities == []


### PR DESCRIPTION
Adds support for the iGarden **Swim Jet** counter-current swimming machine (category `poolSurfer`, productCode `iupstream1`), requested in #85.

### Naming source
Every dp in the diagnostic carries a full `nameLanguage` / `dpPropertyNameLanguage` (en-US + de/fr/es/cs) — that is the naming source, like `sandCylinder`. The raw `dpProperty` enum labels are **stale** here (dp 21 reports `TRAINING_MODE_P1..P6`, dp 22 `POWER_OFF_STATUS`) and disagree with the firmware's own `dpPropertyNameLanguage`, so the mode select maps by integer key.

### Entities
- **Select** — dp 21 Working Mode (free/timed, training 1-4, surf, custom)
- **Number** — dp 23 Speed; dp 28/29/30 per-mode default speed / speed / duration (config)
- **Binary sensor** — dp 4 Driver Board Fault (PROBLEM)
- **Sensors** — model, status, session distance/duration/intensity, motor power, actual/commanded motor speed, bus voltage, motor/bus current, internal temperatures (MOS, electrical box, driver-board NTC 1-3)

Firmware-debug dps (RTOS stack sizes, RCC flags, OTA size, commissioning timers, device log, wifi level, device clock) and the raw training-program blobs are intentionally not exposed.

### Tests
Adds a sanitized `tests/fixtures/pool_surfer.json` and `tests/test_pool_surfer.py`. Full suite passes (67), lint clean, smoke-tested against the full 52-dp device.

Refs #85