### PR TITLE
feat: add swim-jet power switch and fault-code sensor (#85)

### DIFF
--- a/custom_components/fairland/sensor.py
+++ b/custom_components/fairland/sensor.py
@@ -579,6 +579,21 @@ POOL_SURFER_SENSOR_TYPES = {
         "is_enum": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
+    # dp 4 "The driver board is faulty" is a 0-65535 code register (0 = OK),
+    # also surfaced as a binary PROBLEM sensor. Exposed here as the raw code
+    # so it can be cross-referenced against the manual's fault-code table
+    # (E0 01 .. E2 03). The value is shown verbatim, with no interpretation:
+    # the firmware's encoding is unconfirmed (suspected group<<8 | index, e.g.
+    # E2 02 -> 514) and we have no faulted capture to verify it, so no
+    # code->text map is applied.
+    "4": {
+        "name": "Fault Code",
+        "unit": None,
+        "icon": "mdi:alert-circle-outline",
+        "device_class": None,
+        "state_class": None,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
     # Session statistics (firmware "Complete(ion) Statistics_*"). All read 0
     # while the jet is idle.
     "42": {

--- a/custom_components/fairland/switch.py
+++ b/custom_components/fairland/switch.py
@@ -12,6 +12,7 @@ from .const import (
     DOMAIN,
     HEAT_PUMP_CATEGORY_CODE,
     LOGGER,
+    POOL_SURFER_CATEGORY_CODE,
     SALT_MACHINE_CATEGORY_CODE,
     WATER_PUMP_CATEGORY_CODE,
 )
@@ -48,11 +49,27 @@ SALT_MACHINE_SWITCH_TYPES: dict[str, dict[str, Any]] = {
     # (pausing chlorine production during a backwash cycle).
     "153": {"name": "Backwash", "icon": "mdi:water-sync", "require_value": True},
 }
+# Swim jet (poolSurfer, #85). There is no boolean power dp; the on/off state
+# lives in the dp 22 state machine. Powering on runs Free Mode P0 by default
+# (confirmed by the user manual and the on/off diagnostics: dp 22 goes
+# 0 = POWER_OFF -> 3 = FREE_MODE_RUNNING), so the Power switch writes those
+# enum values instead of a bool. `enum_on_value`/`enum_off_value` opt into
+# the enum write/read path; any non-POWER_OFF state reads as on.
+POOL_SURFER_SWITCH_TYPES: dict[str, dict[str, Any]] = {
+    "22": {
+        "name": "Power",
+        "icon": "mdi:power",
+        "is_power": True,
+        "enum_on_value": 3,
+        "enum_off_value": 0,
+    },
+}
 
 CATEGORY_SWITCH_TYPES = {
     HEAT_PUMP_CATEGORY_CODE: HEAT_PUMP_SWITCH_TYPES,
     WATER_PUMP_CATEGORY_CODE: WATER_PUMP_SWITCH_TYPES,
     SALT_MACHINE_CATEGORY_CODE: SALT_MACHINE_SWITCH_TYPES,
+    POOL_SURFER_CATEGORY_CODE: POOL_SURFER_SWITCH_TYPES,
 }
 
 
@@ -126,6 +143,10 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
         self._attr_unique_id = f"{DOMAIN}_{self._device_id}_{suffix}"
         self._attr_name = config["name"]
         self._attr_icon = config.get("icon", "mdi:power")
+        # Enum-backed switches (e.g. the swim jet's dp 22 state machine) write
+        # integer states instead of a bool; on = any value other than "off".
+        self._enum_on = config.get("enum_on_value")
+        self._enum_off = config.get("enum_off_value")
         self._is_on = False
 
         # Device info
@@ -140,12 +161,23 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
         # Initialize the state from device info
         self._update_state()
 
+    def _coerce_on(self, raw: Any) -> bool:
+        """Map a raw dpValue to on/off, honoring an enum on/off mapping."""
+        if self._enum_on is None:
+            return _coerce_bool(raw)
+        if raw is None:
+            return False
+        try:
+            return int(raw) != int(self._enum_off)
+        except (TypeError, ValueError):
+            return False
+
     def _update_state(self):
         """Update state from device data."""
         if "dps" in self._device_info:
             for dp in self._device_info["dps"]:
                 if dp["dpId"] == self._dp_id:
-                    self._is_on = _coerce_bool(
+                    self._is_on = self._coerce_on(
                         self._effective_dp_value(self._dp_id, dp["dpValue"])
                     )
                     self._attr_available = True
@@ -184,16 +216,21 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
 
     async def _async_write(self, value: bool) -> None:
         """Write a new on/off state, holding it optimistically (#77)."""
+        # Enum-backed switches send the mapped integer state (e.g. the swim
+        # jet's dp 22: 3 = FREE_MODE_RUNNING, 0 = POWER_OFF) rather than a bool.
+        write_value: Any = value
+        if self._enum_on is not None:
+            write_value = self._enum_on if value else self._enum_off
         try:
             await self.coordinator.config_entry.runtime_data.client.set_device_status(
                 self._device_id,
                 self._dp_id,
-                value,
+                write_value,
             )
             # Optimistisch setzen; die Cloud meldet den neuen Wert erst nach
             # 2-4 s zurück, ein sofortiger Refresh würde den alten Wert lesen
             # und die UI zurückspringen lassen (#77).
-            self._note_pending_write(self._dp_id, value)
+            self._note_pending_write(self._dp_id, write_value)
             self._is_on = value
             self.async_write_ha_state()
             self._schedule_write_refresh()

--- a/tests/test_pool_surfer.py
+++ b/tests/test_pool_surfer.py
@@ -32,6 +32,7 @@ def test_sensor_dps_created(setup_entities, swim_jet_devices):
     entities, _ = setup_entities("sensor", swim_jet_devices)
     assert set(_by_dp(entities)) == {
         "2",
+        "4",
         "22",
         "42",
         "40",
@@ -48,6 +49,15 @@ def test_sensor_dps_created(setup_entities, swim_jet_devices):
         "51",
         "52",
     }
+
+
+def test_fault_code_raw_value(setup_entities, swim_jet_devices):
+    # dp 4 is the raw fault-code register (0 = OK), shown verbatim with no
+    # code->text interpretation.
+    dps = _by_dp(setup_entities("sensor", swim_jet_devices)[0])
+    assert dps["4"]._attr_native_value == 0
+    assert dps["4"]._enum_map is None
+    assert dps["4"]._attr_entity_category == "DIAGNOSTIC"
 
 
 def test_voltage_scaled(setup_entities, swim_jet_devices):
@@ -161,8 +171,35 @@ def test_driver_board_fault_created(setup_entities, swim_jet_devices):
 
 
 # --------------------------------------------------------------------------
-# No switches / climate for this category
+# Power switch (dp 22 state machine)
 # --------------------------------------------------------------------------
-def test_no_switches(setup_entities, swim_jet_devices):
+def test_power_switch_created(setup_entities, swim_jet_devices):
     entities, _ = setup_entities("switch", swim_jet_devices)
-    assert entities == []
+    switches = _by_dp(entities)
+    assert set(switches) == {"22"}
+    # Captured while off (dp 22 = 0 = POWER_OFF).
+    assert switches["22"].is_on is False
+
+
+def test_power_switch_on_when_running(setup_entities, swim_jet_devices):
+    # dp 22 = 3 (FREE_MODE_RUNNING) reads as on; any non-POWER_OFF state does.
+    devs = [dict(swim_jet_devices[0])]
+    devs[0]["dps"] = [
+        {**dp, "dpValue": 3} if dp["dpId"] == "22" else dp for dp in devs[0]["dps"]
+    ]
+    switches = _by_dp(setup_entities("switch", devs)[0])
+    assert switches["22"].is_on is True
+
+
+def test_power_switch_turn_on_sends_running(setup_entities, swim_jet_devices):
+    entities, client = setup_entities("switch", swim_jet_devices)
+    asyncio.run(_by_dp(entities)["22"].async_turn_on())
+    # On writes 3 (FREE_MODE_RUNNING), matching the power-on default.
+    assert client.calls == [(swim_jet_devices[0]["id"], "22", 3)]
+
+
+def test_power_switch_turn_off_sends_power_off(setup_entities, swim_jet_devices):
+    entities, client = setup_entities("switch", swim_jet_devices)
+    asyncio.run(_by_dp(entities)["22"].async_turn_off())
+    # Off writes 0 (POWER_OFF).
+    assert client.calls == [(swim_jet_devices[0]["id"], "22", 0)]


### PR DESCRIPTION
Follow-up to the poolSurfer support (#86), built from the on/off diagnostics and the user manual @stmeyer1 provided in #85.

### Power switch (dp 22)
The swim jet has no boolean power data point. Powering on runs Free Mode P0 by default, so the dp 22 state machine goes `0` = POWER_OFF ↔ `3` = FREE_MODE_RUNNING (confirmed by the manual §6.2 and the on/off diagnostics). The Power switch writes those enum integers via new `enum_on_value` / `enum_off_value` support in `FairlandSwitch`; any non-POWER_OFF state reads as on.

### Fault Code sensor (dp 4)
dp 4 is a 0-65535 code register (0 = OK), already surfaced as a binary PROBLEM sensor. It is now also exposed as a raw numeric **Fault Code** sensor so the value can be cross-referenced against the manual's fault-code table (E0 01 .. E2 03). No code→text map is applied: the encoding is unverified (suspected `group<<8 | index`) and we have no faulted capture.

### Note on the "all sensors zero" report
That was the off-state. Power, speed, current and the session stats only populate while the jet runs, which the on/off diagnostics confirmed.

Tests updated (71 pass), lint clean. The dp 22 write direction is data-grounded but device-untested; asking the reporter to confirm it starts/stops the jet.

Refs #85