### PR TITLE
fix: drive swim-jet mode change via packed dp 20 (#85)

### DIFF
--- a/custom_components/fairland/select.py
+++ b/custom_components/fairland/select.py
@@ -14,7 +14,9 @@ for the duration configured by the ``Backwash Duration`` number entity
 
 from __future__ import annotations
 
+import base64
 import json
+import struct
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.select import SelectEntity
@@ -141,6 +143,15 @@ SAND_CYLINDER_SELECT_TYPES: dict[str, dict[str, Any]] = {
 # dpPropertyNameLanguage, so options map by the integer key rather than the
 # label (the same approach the sandCylinder selects use).
 #
+# The current mode is *read* from dp 21, but writing dp 21 alone does not
+# switch the mode (confirmed on a real device, #85). The mode change must go
+# through the packed "Mode + Status" raw field dp 20, two little-endian
+# uint16s: mode (= dp 21) and the run state (= dp 22). So a write builds
+# dp 20 = <mode, running-status> and sends it base64-encoded. The running
+# status is 3 (FREE_MODE_RUNNING) for free mode and 13 (TRAINING_MODE_RUNNING)
+# for the training/surf/custom modes, matching what the on/off/mode
+# diagnostics reported. `option_to_mode_status` maps each option to that pair.
+#
 # NOTE: selecting a training/surf program starts the jet running it.
 POOL_SURFER_SELECT_TYPES: dict[str, dict[str, Any]] = {
     "21": {
@@ -154,6 +165,16 @@ POOL_SURFER_SELECT_TYPES: dict[str, dict[str, Any]] = {
             4: "training_4",
             5: "surf",
             6: "custom",
+        },
+        "write_raw_dp": "20",
+        "option_to_mode_status": {
+            "free_or_timed": (0, 3),
+            "training_1": (1, 13),
+            "training_2": (2, 13),
+            "training_3": (3, 13),
+            "training_4": (4, 13),
+            "surf": (5, 13),
+            "custom": (6, 13),
         },
     },
 }
@@ -400,6 +421,10 @@ class FairlandDpSelect(FairlandEntity, SelectEntity):
         self._int_to_option_override = config.get("int_to_option")
         self._int_to_option: dict[int, str] = {}
         self._option_to_int: dict[str, int] = {}
+        # Swim-jet mode: written via the packed dp 20 raw field instead of the
+        # read dp (writing dp 21 alone does nothing). See POOL_SURFER_SELECT_TYPES.
+        self._write_raw_dp = config.get("write_raw_dp")
+        self._option_mode_status = config.get("option_to_mode_status")
 
         self._attr_icon = config.get("icon")
         self._attr_translation_key = config.get("translation_key")
@@ -455,11 +480,26 @@ class FairlandDpSelect(FairlandEntity, SelectEntity):
             )
             return
         target_int = self._option_to_int[option]
+        # Normally the option's integer is written straight to the read dp.
+        # For the swim-jet mode, the device only reacts to the packed dp 20
+        # "Mode + Status" field, so build <mode, running-status> as two
+        # little-endian uint16s and send it base64-encoded. Either way the
+        # pending write is noted on the read dp (dp 21 == mode) so the option
+        # holds optimistically until the device reports the new mode back.
+        if self._write_raw_dp is not None and self._option_mode_status is not None:
+            mode, status = self._option_mode_status[option]
+            write_dp = self._write_raw_dp
+            write_value: Any = base64.b64encode(
+                struct.pack("<HH", mode, status)
+            ).decode()
+        else:
+            write_dp = self._dp_id
+            write_value = target_int
         try:
             await self.coordinator.config_entry.runtime_data.client.set_device_status(
                 self._device_id,
-                self._dp_id,
-                target_int,
+                write_dp,
+                write_value,
             )
             # Optimistisch setzen; die Cloud meldet den neuen Wert erst nach
             # 2-4 s zurück (#77).

--- a/custom_components/fairland/sensor.py
+++ b/custom_components/fairland/sensor.py
@@ -617,13 +617,17 @@ POOL_SURFER_SENSOR_TYPES = {
         "device_class": None,
         "state_class": SensorStateClass.MEASUREMENT,
     },
-    # Electrical telemetry (all diagnostic).
+    # Electrical telemetry (all diagnostic). Motor Power (dp 12) is diagnostic
+    # like the rest: this firmware reports it as 0 even while running (the
+    # on/off/mode diagnostics all showed 0 W), so it should not sit on the
+    # main sensor card as a primary reading.
     "12": {
         "name": "Motor Power",
         "unit": UnitOfPower.WATT,
         "icon": "mdi:flash",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
+        "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "9": {
         "name": "Motor Speed",

--- a/tests/test_pool_surfer.py
+++ b/tests/test_pool_surfer.py
@@ -51,6 +51,13 @@ def test_sensor_dps_created(setup_entities, swim_jet_devices):
     }
 
 
+def test_motor_power_is_diagnostic(setup_entities, swim_jet_devices):
+    # dp 12 reads 0 W even while running on this firmware, so it lives in the
+    # diagnostic section rather than on the main sensor card.
+    dps = _by_dp(setup_entities("sensor", swim_jet_devices)[0])
+    assert dps["12"]._attr_entity_category == "DIAGNOSTIC"
+
+
 def test_fault_code_raw_value(setup_entities, swim_jet_devices):
     # dp 4 is the raw fault-code register (0 = OK), shown verbatim with no
     # code->text interpretation.
@@ -152,11 +159,27 @@ def test_mode_options_by_int_key(setup_entities, swim_jet_devices):
     assert mode._attr_current_option == "free_or_timed"
 
 
-def test_mode_write_sends_int(setup_entities, swim_jet_devices):
+def test_mode_write_packs_dp20(setup_entities, swim_jet_devices):
+    # Writing dp 21 alone does nothing on the device; the mode change goes
+    # through the packed dp 20 "Mode + Status" field. "surf" = mode 5, running
+    # status 13 -> bytes [5,0,13,0] -> base64 "BQANAA==".
     entities, client = setup_entities("select", swim_jet_devices)
     asyncio.run(_by_dp(entities)["21"].async_select_option("surf"))
-    # "surf" maps to firmware int 5.
-    assert client.calls == [(swim_jet_devices[0]["id"], "21", 5)]
+    assert client.calls == [(swim_jet_devices[0]["id"], "20", "BQANAA==")]
+
+
+def test_mode_write_free_packs_free_running(setup_entities, swim_jet_devices):
+    # "free_or_timed" = mode 0, running status 3 -> [0,0,3,0] -> "AAADAA==".
+    entities, client = setup_entities("select", swim_jet_devices)
+    asyncio.run(_by_dp(entities)["21"].async_select_option("free_or_timed"))
+    assert client.calls == [(swim_jet_devices[0]["id"], "20", "AAADAA==")]
+
+
+def test_mode_write_training2_packs_dp20(setup_entities, swim_jet_devices):
+    # "training_2" = mode 2, running status 13 -> [2,0,13,0] -> "AgANAA==".
+    entities, client = setup_entities("select", swim_jet_devices)
+    asyncio.run(_by_dp(entities)["21"].async_select_option("training_2"))
+    assert client.calls == [(swim_jet_devices[0]["id"], "20", "AgANAA==")]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #85. @stmeyer1 confirmed the Power switch works, but the **Working Mode** select did not change the mode: writing dp 21 alone has no effect on the device.

### Root cause
Decoding the dp 20 "Mode + Status" raw field across the free / timer / surf / training-2 diagnostics showed it packs two little-endian uint16s:

| dp 20 | bytes | mode (=dp21) | status (=dp22) |
|-------|-------|--------------|----------------|
| `AAADAA==` | [0,0,3,0] | 0 | 3 free running |
| `AAAIAA==` | [0,0,8,0] | 0 | 8 timer running |
| `BQANAA==` | [5,0,13,0] | 5 | 13 surf running |
| `AgANAA==` | [2,0,13,0] | 2 | 13 training-2 running |

So a mode change needs the combined field, not the isolated dp 21.

### Change
The mode select now **reads dp 21** as before but **writes dp 20** = `<mode, running-status>` base64-encoded (running-status 3 for free, 13 for training/surf/custom), via new `write_raw_dp` / `option_to_mode_status` config on `FairlandDpSelect`. The pending write is still tracked on dp 21 so the option holds optimistically until the device reports the new mode back (and honestly snaps back if the device rejects it).

Also moves **Motor Power (dp 12)** to the diagnostic section: this firmware reports it as 0 W even while running (all diagnostics confirmed), so it should not sit on the main sensor card.

Also confirmed from the new dumps: the session stats (distance/duration/intensity) do populate in timer/surf/training modes, and stay at zero only in Free Mode.

Tests updated (74 pass), lint clean. The dp 20 write is data-grounded but device-untested; asking the reporter to confirm mode switching now works.

Refs #85