### PR TITLE
feat: add swim-jet pause switch (#85)

### DIFF
--- a/custom_components/fairland/switch.py
+++ b/custom_components/fairland/switch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import struct
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.switch import SwitchEntity
@@ -72,6 +74,27 @@ CATEGORY_SWITCH_TYPES = {
     POOL_SURFER_CATEGORY_CODE: POOL_SURFER_SWITCH_TYPES,
 }
 
+# Swim-jet pause control (#85). The dp 22 state machine has a suspend state
+# per mode family (the manual's Mode-button pause). Pausing/resuming writes
+# the packed dp 20 "Mode + Status" field (like the mode select), keeping the
+# current mode and toggling only the run state between running and suspend:
+#   free    running 3 <-> suspend 4
+#   timer   running 8 <-> suspend 9
+#   training/surf/custom running 13 <-> suspend 14
+# Only the training/surf suspend (14) is observed in a diagnostic; free/timer
+# follow the same running+1 pattern.
+SWIM_JET_MODE_STATUS_DP = "20"
+SWIM_JET_STATUS_DP = "22"
+SWIM_JET_MODE_DP = "21"
+SWIM_JET_SUSPEND_FOR_RUNNING = {3: 4, 8: 9, 13: 14}
+SWIM_JET_RESUME_FOR_SUSPEND = {4: 3, 9: 8, 14: 13}
+SWIM_JET_SUSPEND_STATES = frozenset(SWIM_JET_RESUME_FOR_SUSPEND)
+
+
+def _pack_mode_status(mode: int, status: int) -> str:
+    """Pack a swim-jet <mode, status> pair into the base64 dp 20 raw value."""
+    return base64.b64encode(struct.pack("<HH", mode, status)).decode()
+
 
 def _coerce_bool(raw: Any) -> bool:
     """Coerce a dpValue (bool / 0|1 / "0"|"1"|"on") to a switch state."""
@@ -113,6 +136,20 @@ async def async_setup_entry(
                     device_info=device_info,
                     dp_id=dp_id,
                     config=config,
+                )
+            )
+
+        # Swim jet: add a Pause switch alongside the Power switch when the
+        # state machine (dp 22) and the mode/status write field (dp 20) exist.
+        if (
+            device_info.get("categoryCode") == POOL_SURFER_CATEGORY_CODE
+            and SWIM_JET_STATUS_DP in dp_map
+            and SWIM_JET_MODE_STATUS_DP in dp_map
+        ):
+            entities.append(
+                FairlandSwimJetPauseSwitch(
+                    coordinator=entry.runtime_data.coordinator,
+                    device_info=device_info,
                 )
             )
     async_add_entities(entities, True)
@@ -244,3 +281,107 @@ class FairlandSwitch(FairlandEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
         await self._async_write(False)
+
+
+class FairlandSwimJetPauseSwitch(FairlandEntity, SwitchEntity):
+    """Pause/resume switch for the swim jet (#85).
+
+    On = the jet is suspended (paused). Toggling writes the packed dp 20
+    "Mode + Status" field, keeping the current mode and switching only the run
+    state between running and suspend. It is a no-op when the jet is off or
+    already in the requested state.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:pause"
+
+    def __init__(
+        self,
+        coordinator: FairlandDataUpdateCoordinator,
+        device_info: dict[str, Any],
+    ) -> None:
+        """Initialize the pause switch."""
+        super().__init__(coordinator)
+
+        self._device_info = device_info
+        self._device_id = device_info["id"]
+        self._attr_name = "Pause"
+        self._attr_unique_id = f"{DOMAIN}_{self._device_id}_pause"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_info["deviceName"],
+            manufacturer="Fairland",
+            model=device_info.get("deviceName", "Unknown"),
+            sw_version=device_info.get("version", "Unknown"),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    def _read_int(self, dp_id: str) -> int | None:
+        """Return a dp's current integer value, honoring pending writes."""
+        for dp in self._device_info.get("dps", []):
+            if dp["dpId"] == dp_id:
+                raw = self._effective_dp_value(dp_id, dp.get("dpValue"))
+                try:
+                    return int(raw)
+                except (TypeError, ValueError):
+                    return None
+        return None
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the jet is currently suspended (paused)."""
+        return self._read_int(SWIM_JET_STATUS_DP) in SWIM_JET_SUSPEND_STATES
+
+    async def _write_status(self, status: int) -> None:
+        """Write <current mode, status> to the packed dp 20 field."""
+        mode = self._read_int(SWIM_JET_MODE_DP) or 0
+        try:
+            await self.coordinator.config_entry.runtime_data.client.set_device_status(
+                self._device_id,
+                SWIM_JET_MODE_STATUS_DP,
+                _pack_mode_status(mode, status),
+            )
+            # Hold the new run state optimistically until the cloud catches up
+            # (#77); is_on reads dp 22, so the pending write is noted there.
+            self._note_pending_write(SWIM_JET_STATUS_DP, status)
+            self.async_write_ha_state()
+            self._schedule_write_refresh()
+        except (FairlandApiClientCommunicationError, FairlandApiClientError) as ex:
+            LOGGER.error("Error setting swim-jet pause state: %s", ex)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Pause: suspend the currently running mode."""
+        status = self._read_int(SWIM_JET_STATUS_DP)
+        target = SWIM_JET_SUSPEND_FOR_RUNNING.get(status)
+        if target is None:
+            LOGGER.debug("Pause ignored: swim jet not running (status=%s)", status)
+            return
+        await self._write_status(target)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Resume: return the suspended mode to running."""
+        status = self._read_int(SWIM_JET_STATUS_DP)
+        target = SWIM_JET_RESUME_FOR_SUSPEND.get(status)
+        if target is None:
+            LOGGER.debug("Resume ignored: swim jet not paused (status=%s)", status)
+            return
+        await self._write_status(target)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_coordinator_update)
+        )
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        for device in self.coordinator.data:
+            if device["id"] == self._device_id:
+                self._device_info = device
+                self.async_write_ha_state()
+                break

--- a/tests/fixtures/pool_surfer.json
+++ b/tests/fixtures/pool_surfer.json
@@ -75,6 +75,13 @@
       "dpType": "value"
     },
     {
+      "dpId": "20",
+      "dpValue": "AAAAAA==",
+      "dpProperty": "{}",
+      "dpMode": "rw",
+      "dpType": "raw"
+    },
+    {
       "dpId": "21",
       "dpValue": 0,
       "dpProperty": "{\"0\": \"自由或定时模式\", \"1\": \"TRAINING_MODE_P1\", \"2\": \"TRAINING_MODE_P2\", \"3\": \"TRAINING_MODE_P3\", \"4\": \"TRAINING_MODE_P4\", \"5\": \"TRAINING_MODE_P5\", \"6\": \"TRAINING_MODE_P6\"}",

--- a/tests/test_pool_surfer.py
+++ b/tests/test_pool_surfer.py
@@ -22,7 +22,22 @@ def swim_jet_devices() -> list[dict]:
 
 
 def _by_dp(entities: list) -> dict:
-    return {e._dp_id: e for e in entities}
+    # The pause switch has no single backing dp, so key only the dp-bound ones.
+    return {e._dp_id: e for e in entities if hasattr(e, "_dp_id")}
+
+
+def _by_name(entities: list, name: str):
+    return next(e for e in entities if getattr(e, "_attr_name", None) == name)
+
+
+def _with_dps(device: dict, overrides: dict) -> list[dict]:
+    """Clone a device with some dpValues overridden (by dpId)."""
+    clone = dict(device)
+    clone["dps"] = [
+        {**dp, "dpValue": overrides.get(dp["dpId"], dp["dpValue"])}
+        for dp in device["dps"]
+    ]
+    return [clone]
 
 
 # --------------------------------------------------------------------------
@@ -226,3 +241,44 @@ def test_power_switch_turn_off_sends_power_off(setup_entities, swim_jet_devices)
     asyncio.run(_by_dp(entities)["22"].async_turn_off())
     # Off writes 0 (POWER_OFF).
     assert client.calls == [(swim_jet_devices[0]["id"], "22", 0)]
+
+
+# --------------------------------------------------------------------------
+# Pause switch (dp 22 suspend states, written via packed dp 20)
+# --------------------------------------------------------------------------
+def test_pause_switch_created(setup_entities, swim_jet_devices):
+    entities, _ = setup_entities("switch", swim_jet_devices)
+    names = {getattr(e, "_attr_name", None) for e in entities}
+    assert {"Power", "Pause"} <= names
+    # Captured while off (dp 22 = 0) → not paused.
+    assert _by_name(entities, "Pause").is_on is False
+
+
+def test_pause_when_free_running(setup_entities, swim_jet_devices):
+    # Free running (dp 22 = 3, mode 0): pausing writes <mode 0, suspend 4> →
+    # bytes [0,0,4,0] → "AAAEAA==".
+    devs = _with_dps(swim_jet_devices[0], {"22": 3, "21": 0})
+    entities, client = setup_entities("switch", devs)
+    pause = _by_name(entities, "Pause")
+    assert pause.is_on is False
+    asyncio.run(pause.async_turn_on())
+    assert client.calls == [(devs[0]["id"], "20", "AAAEAA==")]
+    assert pause.is_on is True  # optimistic hold on dp 22 = 4
+
+
+def test_resume_when_surf_paused(setup_entities, swim_jet_devices):
+    # Surf paused (dp 22 = 14, mode 5): resuming writes <mode 5, running 13> →
+    # bytes [5,0,13,0] → "BQANAA==".
+    devs = _with_dps(swim_jet_devices[0], {"22": 14, "21": 5})
+    entities, client = setup_entities("switch", devs)
+    pause = _by_name(entities, "Pause")
+    assert pause.is_on is True
+    asyncio.run(pause.async_turn_off())
+    assert client.calls == [(devs[0]["id"], "20", "BQANAA==")]
+
+
+def test_pause_noop_when_off(setup_entities, swim_jet_devices):
+    # dp 22 = 0 (off): pausing does nothing (nothing running to suspend).
+    entities, client = setup_entities("switch", swim_jet_devices)
+    asyncio.run(_by_name(entities, "Pause").async_turn_on())
+    assert client.calls == []


### PR DESCRIPTION
Adds a **Pause** switch for the swim jet, requested via #85.

@stmeyer1 confirmed the mode switching (v0.7.2) works and sent a surf-mode pause diagnostic, which showed the paused state as dp 22 = 14 (`TRAINING_MODE_SUSPEND`), dp 20 = `[5,0,14,0]`.

### Behaviour
Toggling the switch writes the packed dp 20 "Mode + Status" field, keeping the current working mode and switching only the run state between running and suspend:

| family | running ↔ suspend |
|--------|-------------------|
| free | 3 ↔ 4 |
| timer | 8 ↔ 9 |
| training / surf / custom | 13 ↔ 14 |

- **On** = the jet is suspended (dp 22 in a suspend state).
- No-op when the jet is off or already in the requested state.
- Only the training/surf suspend (14) is observed in a diagnostic; free/timer follow the same running+1 pattern.

Also adds dp 20 to the `pool_surfer` fixture (it exists on the device and is needed for both the pause switch and the mode-write path).

Tests updated (78 pass), lint clean.

Refs #85